### PR TITLE
Make Remark an optional field

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -82,7 +82,7 @@ Format: *`help`*
 
 Adds a bookmark to the bookmark manager.
 
-Format: `*add* u/URL n/NAME [f/FOLDER] [t/TAG]…​`
+Format: `*add* u/URL n/NAME [f/FOLDER] [t/TAG]…​ [r/REMARK]`
 
 ****
 * A bookmark can have any number of tags (including 0).
@@ -95,7 +95,9 @@ Examples:
 * `*add* u/this n/Homepage` +
 Bookmarks the current place and names it `Homepage`.
 Only valid if a web-page is currently being viewed.
-* `*add* u/nus-cs2103-ay1920s1.github.io n/Module Website f/CS2103T`
+* `*add* u/nus-cs2103-ay1920s1.github.io n/Module Website f/CS2103T r/Contains textbook & important deadlines` +
+Bookmarks the given website, names it `Module Website`, and adds it to the folder `CS2103T`.
+The new bookmark's remark is "Contains textbook & important deadlines".
 * `*add* u/www.youtube.com/watch?v=9AMcN-wkspU n/IntelliJ Tips and Tricks t/video t/watch-later`
 
 === Listing all bookmarks: *`list`*

--- a/src/main/java/seedu/mark/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/AddCommand.java
@@ -21,7 +21,7 @@ public class AddCommand extends Command {
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_URL + "URL "
-            + PREFIX_REMARK + "REMARK " // TODO: Make REMARK an optional field
+            + "[" + PREFIX_REMARK + "REMARK] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe " // TODO: Change AddCommand example

--- a/src/main/java/seedu/mark/logic/commands/exceptions/CommandException.java
+++ b/src/main/java/seedu/mark/logic/commands/exceptions/CommandException.java
@@ -1,5 +1,7 @@
 package seedu.mark.logic.commands.exceptions;
 
+import seedu.mark.logic.commands.Command;
+
 /**
  * Represents an error which occurs during execution of a {@link Command}.
  */

--- a/src/main/java/seedu/mark/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/mark/logic/parser/AddCommandParser.java
@@ -31,14 +31,17 @@ public class AddCommandParser implements Parser<AddCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_URL, PREFIX_REMARK, PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_REMARK, PREFIX_URL)
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_URL)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
+        // compulsory fields
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Url url = ParserUtil.parseUrl(argMultimap.getValue(PREFIX_URL).get());
-        Remark remark = ParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK).get());
+
+        // optional fields
+        Remark remark = ParserUtil.parseRemark(argMultimap.getValue(PREFIX_REMARK).orElse(Remark.DEFAULT_VALUE));
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         Bookmark bookmark = new Bookmark(name, url, remark, tagList);

--- a/src/main/java/seedu/mark/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/mark/logic/parser/ParserUtil.java
@@ -52,15 +52,20 @@ public class ParserUtil {
     /**
      * Parses a {@code String remark} into an {@code Remark}.
      * Leading and trailing whitespaces will be trimmed.
+     * Empty remarks will be replaced by the default {@code Remark}.
      *
      * @throws ParseException if the given {@code remark} is invalid.
      */
     public static Remark parseRemark(String remark) throws ParseException {
         requireNonNull(remark);
         String trimmedRemark = remark.trim();
-        if (!Remark.isValidRemark(trimmedRemark)) {
+
+        if (Remark.isEmptyRemark(trimmedRemark)) {
+            return Remark.getDefaultRemark();
+        } else if (!Remark.isValidRemark(trimmedRemark)) {
             throw new ParseException(Remark.MESSAGE_CONSTRAINTS);
         }
+
         return new Remark(trimmedRemark);
     }
 

--- a/src/main/java/seedu/mark/model/bookmark/Bookmark.java
+++ b/src/main/java/seedu/mark/model/bookmark/Bookmark.java
@@ -64,8 +64,8 @@ public class Bookmark {
         }
 
         return otherBookmark != null
-                && otherBookmark.getName().equals(getName())
-                && otherBookmark.getUrl().equals(getUrl());
+                && (otherBookmark.getName().equals(getName())
+                    || otherBookmark.getUrl().equals(getUrl()));
     }
 
     /**

--- a/src/main/java/seedu/mark/model/bookmark/Remark.java
+++ b/src/main/java/seedu/mark/model/bookmark/Remark.java
@@ -9,14 +9,17 @@ import static seedu.mark.commons.util.AppUtil.checkArgument;
  */
 public class Remark {
 
-    public static final String MESSAGE_CONSTRAINTS = "Remarks can take any values, and it should not be blank";
+    public static final String SPECIAL_CHARACTER = "/";
+
+    public static final String MESSAGE_CONSTRAINTS = "Remarks can contain any characters except " + SPECIAL_CHARACTER;
 
     /*
      * The first character of the remark must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[^\\s].*";
+    public static final String VALIDATION_REGEX = "[^\\s][^" + SPECIAL_CHARACTER + "]*";
 
+    public static final String DEFAULT_VALUE = "-";
     public final String value;
 
     /**
@@ -35,6 +38,20 @@ public class Remark {
      */
     public static boolean isValidRemark(String test) {
         return test.matches(VALIDATION_REGEX);
+    }
+
+    /**
+     * Returns true if a given string is an empty remark.
+     */
+    public static boolean isEmptyRemark(String test) {
+        return test.trim().equals("");
+    }
+
+    /**
+     * Returns a {@code Remark} with the default value.
+     */
+    public static Remark getDefaultRemark() {
+        return new Remark(DEFAULT_VALUE);
     }
 
     @Override

--- a/src/main/java/seedu/mark/model/bookmark/Remark.java
+++ b/src/main/java/seedu/mark/model/bookmark/Remark.java
@@ -9,15 +9,17 @@ import static seedu.mark.commons.util.AppUtil.checkArgument;
  */
 public class Remark {
 
-    public static final String SPECIAL_CHARACTER = "/";
+    public static final String INVALID_CHARACTER = "/";
 
-    public static final String MESSAGE_CONSTRAINTS = "Remarks can contain any characters except " + SPECIAL_CHARACTER;
+    public static final String MESSAGE_CONSTRAINTS = "Remarks can contain any characters except " + INVALID_CHARACTER;
 
     /*
      * The first character of the remark must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
+     *
+     * The rest of the remark can contain any character except the invalid character.
      */
-    public static final String VALIDATION_REGEX = "[^\\s][^" + SPECIAL_CHARACTER + "]*";
+    public static final String VALIDATION_REGEX = "[^\\s][^" + INVALID_CHARACTER + "]*";
 
     public static final String DEFAULT_VALUE = "-";
     public final String value;

--- a/src/test/java/seedu/mark/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/mark/logic/commands/CommandTestUtil.java
@@ -45,7 +45,7 @@ public class CommandTestUtil {
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_URL_DESC = " " + PREFIX_URL + "bob??yahoo"; // double '?'
-    public static final String INVALID_REMARK_DESC = " " + PREFIX_REMARK; // empty string not allowed for remarks
+    public static final String INVALID_REMARK_DESC = " " + PREFIX_REMARK + "t/ means tag"; // '/' not allowed in remarks
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";

--- a/src/test/java/seedu/mark/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/AddCommandParserTest.java
@@ -67,8 +67,12 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_optionalFieldsMissing_success() {
+        // no remark
+        Bookmark expectedBookmark = new BookmarkBuilder(AMY).withRemark(Remark.DEFAULT_VALUE).build();
+        assertParseSuccess(parser, NAME_DESC_AMY + URL_DESC_AMY + TAG_DESC_FRIEND, new AddCommand(expectedBookmark));
+
         // zero tags
-        Bookmark expectedBookmark = new BookmarkBuilder(AMY).withTags().build();
+        expectedBookmark = new BookmarkBuilder(AMY).withTags().build();
         assertParseSuccess(parser, NAME_DESC_AMY + URL_DESC_AMY + REMARK_DESC_AMY,
                 new AddCommand(expectedBookmark));
     }
@@ -83,10 +87,6 @@ public class AddCommandParserTest {
 
         // missing url prefix
         assertParseFailure(parser, NAME_DESC_BOB + VALID_URL_BOB + REMARK_DESC_BOB,
-                expectedMessage);
-
-        // missing remark prefix
-        assertParseFailure(parser, NAME_DESC_BOB + URL_DESC_BOB + VALID_REMARK_BOB,
                 expectedMessage);
 
         // all prefixes missing
@@ -113,7 +113,7 @@ public class AddCommandParserTest {
                 + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
-        assertParseFailure(parser, INVALID_NAME_DESC + URL_DESC_BOB + INVALID_REMARK_DESC,
+        assertParseFailure(parser, INVALID_NAME_DESC + INVALID_URL_DESC,
                 Name.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble

--- a/src/test/java/seedu/mark/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/mark/logic/parser/ParserUtilTest.java
@@ -22,7 +22,7 @@ import seedu.mark.model.tag.Tag;
 public class ParserUtilTest {
     private static final String INVALID_NAME = "R@chel";
     private static final String INVALID_URL = "exam?ple.com?";
-    private static final String INVALID_REMARK = " ";
+    private static final String INVALID_REMARK = "t/ means tag";
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = "Rachel Walker";
@@ -84,6 +84,12 @@ public class ParserUtilTest {
     @Test
     public void parseRemark_invalidValue_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseRemark(INVALID_REMARK));
+    }
+
+    @Test
+    public void parseRemark_validValueEmpty_returnsDefaultRemark() throws Exception {
+        Remark expectedRemark = new Remark(Remark.DEFAULT_VALUE);
+        assertEquals(expectedRemark, ParserUtil.parseRemark(WHITESPACE));
     }
 
     @Test

--- a/src/test/java/seedu/mark/model/bookmark/BookmarkTest.java
+++ b/src/test/java/seedu/mark/model/bookmark/BookmarkTest.java
@@ -30,13 +30,18 @@ public class BookmarkTest {
         // null -> returns false
         assertFalse(ALICE.isSameBookmark(null));
 
-        // different url -> returns false
-        Bookmark editedAlice = new BookmarkBuilder(ALICE).withUrl(VALID_URL_BOB).build();
+        // different name, different url -> returns false
+        Bookmark editedAlice = new BookmarkBuilder(ALICE).withName(VALID_NAME_BOB)
+                .withUrl(VALID_URL_BOB).build();
         assertFalse(ALICE.isSameBookmark(editedAlice));
 
-        // different name -> returns false
+        // same name, different url -> returns true
+        editedAlice = new BookmarkBuilder(ALICE).withUrl(VALID_URL_BOB).build();
+        assertTrue(ALICE.isSameBookmark(editedAlice));
+
+        // different name, same url -> returns true
         editedAlice = new BookmarkBuilder(ALICE).withName(VALID_NAME_BOB).build();
-        assertFalse(ALICE.isSameBookmark(editedAlice));
+        assertTrue(ALICE.isSameBookmark(editedAlice));
 
         // same name, same url, different attributes -> returns true
         editedAlice = new BookmarkBuilder(ALICE).withRemark(VALID_REMARK_BOB)

--- a/src/test/java/seedu/mark/model/bookmark/RemarkTest.java
+++ b/src/test/java/seedu/mark/model/bookmark/RemarkTest.java
@@ -27,10 +27,24 @@ public class RemarkTest {
         // invalid remarks
         assertFalse(Remark.isValidRemark("")); // empty string
         assertFalse(Remark.isValidRemark(" ")); // spaces only
+        assertFalse(Remark.isValidRemark(" r/r")); // contains forward slash
 
         // valid remarks
         assertTrue(Remark.isValidRemark("Blk 456, Den Road, #01-355"));
         assertTrue(Remark.isValidRemark("-")); // one character
         assertTrue(Remark.isValidRemark("Leng Inc; 1234 Market St; San Francisco CA 2349879; USA")); // long remark
+    }
+
+    @Test
+    public void isEmptyRemark() {
+        // null remark
+        assertThrows(NullPointerException.class, () -> Remark.isEmptyRemark(null));
+
+        // empty remarks
+        assertTrue(Remark.isEmptyRemark("")); // empty string
+        assertTrue(Remark.isEmptyRemark(" ")); // spaces only
+
+        // non-empty remark
+        assertFalse(Remark.isEmptyRemark("abc"));
     }
 }

--- a/src/test/java/seedu/mark/storage/JsonAdaptedBookmarkTest.java
+++ b/src/test/java/seedu/mark/storage/JsonAdaptedBookmarkTest.java
@@ -18,8 +18,8 @@ import seedu.mark.model.bookmark.Url;
 
 public class JsonAdaptedBookmarkTest {
     private static final String INVALID_NAME = "R@chel";
-    private static final String INVALID_REMARK = " ";
     private static final String INVALID_URL = "exam?ple.com?";
+    private static final String INVALID_REMARK = "t/ means tag";
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = BENSON.getName().toString();

--- a/src/test/java/seedu/mark/testutil/BookmarkBuilder.java
+++ b/src/test/java/seedu/mark/testutil/BookmarkBuilder.java
@@ -15,8 +15,8 @@ import seedu.mark.model.util.SampleDataUtil;
  */
 public class BookmarkBuilder {
 
-    public static final String DEFAULT_NAME = "Alice Pauline";
-    public static final String DEFAULT_URL = "https://alice-pauline.com";
+    public static final String DEFAULT_NAME = "Alice Lee Website";
+    public static final String DEFAULT_URL = "https://alice-lee.com";
     public static final String DEFAULT_REMARK = "123, Jurong West Ave 6, #08-111";
 
     private Name name;


### PR DESCRIPTION
Fixes #35 

Changes:

1. Not necessary to include a remark when adding bookmarks.
2. Empty remarks (i.e. `r/` and `r/   `) will be replaced by a default empty value (`-`).
3. Remarks containing `/` are invalid.

Miscellaneous fixes:

1. Bookmarks are recognised as identical if *either* name or URL is the same.
2. Broken link to `Command` class in `CommandException` javadoc