### PR TITLE
Implement basic undo&redo

### DIFF
--- a/src/main/java/seedu/mark/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/AddCommand.java
@@ -53,6 +53,7 @@ public class AddCommand extends Command {
         }
 
         model.addBookmark(toAdd);
+        model.commitMark();
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 

--- a/src/main/java/seedu/mark/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/AddCommand.java
@@ -53,7 +53,7 @@ public class AddCommand extends Command {
         }
 
         model.addBookmark(toAdd);
-        model.commitMark();
+        model.saveMark();
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 

--- a/src/main/java/seedu/mark/logic/commands/AddFolderCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/AddFolderCommand.java
@@ -50,6 +50,7 @@ public class AddFolderCommand extends Command {
         }
 
         model.addFolder(folder, parentFolder);
+        model.saveMark();
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, folder));
     }

--- a/src/main/java/seedu/mark/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/ClearCommand.java
@@ -19,6 +19,7 @@ public class ClearCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setMark(new Mark());
+        model.commitMark();
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/mark/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/ClearCommand.java
@@ -19,7 +19,7 @@ public class ClearCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setMark(new Mark());
-        model.commitMark();
+        model.saveMark();
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/mark/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/DeleteCommand.java
@@ -42,7 +42,7 @@ public class DeleteCommand extends Command {
 
         Bookmark bookmarkToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteBookmark(bookmarkToDelete);
-        model.commitMark();
+        model.saveMark();
         return new CommandResult(String.format(MESSAGE_DELETE_BOOKMARK_SUCCESS, bookmarkToDelete));
     }
 

--- a/src/main/java/seedu/mark/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/DeleteCommand.java
@@ -42,6 +42,7 @@ public class DeleteCommand extends Command {
 
         Bookmark bookmarkToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteBookmark(bookmarkToDelete);
+        model.commitMark();
         return new CommandResult(String.format(MESSAGE_DELETE_BOOKMARK_SUCCESS, bookmarkToDelete));
     }
 

--- a/src/main/java/seedu/mark/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/EditCommand.java
@@ -82,7 +82,7 @@ public class EditCommand extends Command {
         }
 
         model.setBookmark(bookmarkToEdit, editedBookmark);
-        model.commitMark();
+        model.saveMark();
         model.updateFilteredBookmarkList(PREDICATE_SHOW_ALL_BOOKMARKS);
         return new CommandResult(String.format(MESSAGE_EDIT_BOOKMARK_SUCCESS, editedBookmark));
     }

--- a/src/main/java/seedu/mark/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/EditCommand.java
@@ -82,6 +82,7 @@ public class EditCommand extends Command {
         }
 
         model.setBookmark(bookmarkToEdit, editedBookmark);
+        model.commitMark();
         model.updateFilteredBookmarkList(PREDICATE_SHOW_ALL_BOOKMARKS);
         return new CommandResult(String.format(MESSAGE_EDIT_BOOKMARK_SUCCESS, editedBookmark));
     }

--- a/src/main/java/seedu/mark/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/RedoCommand.java
@@ -8,7 +8,7 @@ import seedu.mark.logic.commands.exceptions.CommandException;
 import seedu.mark.model.Model;
 
 /**
- * Reverts the {@code model}'s mark to its previously undone state.
+ * Reverts the {@code model}'s Mark to its previously undone state.
  */
 public class RedoCommand extends Command {
 

--- a/src/main/java/seedu/mark/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/RedoCommand.java
@@ -1,0 +1,30 @@
+package seedu.mark.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.mark.model.Model.PREDICATE_SHOW_ALL_BOOKMARKS;
+
+import seedu.mark.logic.commands.exceptions.CommandException;
+import seedu.mark.model.Model;
+
+/**
+ * Reverts the {@code model}'s mark to its previously undone state.
+ */
+public class RedoCommand extends Command {
+
+    public static final String COMMAND_WORD = "redo";
+    public static final String MESSAGE_SUCCESS = "Redo success!";
+    public static final String MESSAGE_FAILURE = "No more commands to redo!";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (!model.canRedoMark()) {
+            throw new CommandException(MESSAGE_FAILURE);
+        }
+
+        model.redoMark();
+        model.updateFilteredBookmarkList(PREDICATE_SHOW_ALL_BOOKMARKS);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/mark/logic/commands/RedoCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/RedoCommand.java
@@ -3,6 +3,7 @@ package seedu.mark.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.mark.model.Model.PREDICATE_SHOW_ALL_BOOKMARKS;
 
+import seedu.mark.logic.commands.commandresult.CommandResult;
 import seedu.mark.logic.commands.exceptions.CommandException;
 import seedu.mark.model.Model;
 

--- a/src/main/java/seedu/mark/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/UndoCommand.java
@@ -1,0 +1,29 @@
+package seedu.mark.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.mark.model.Model.PREDICATE_SHOW_ALL_BOOKMARKS;
+
+import seedu.mark.logic.commands.exceptions.CommandException;
+import seedu.mark.model.Model;
+
+/**
+ * Reverts the {@code model}'s mark to its previous state.
+ */
+public class UndoCommand extends Command {
+    public static final String COMMAND_WORD = "undo";
+    public static final String MESSAGE_SUCCESS = "Undo success!";
+    public static final String MESSAGE_FAILURE = "No more commands to undo!";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (!model.canUndoMark()) {
+            throw new CommandException(MESSAGE_FAILURE);
+        }
+
+        model.undoMark();
+        model.updateFilteredBookmarkList(PREDICATE_SHOW_ALL_BOOKMARKS);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/mark/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/UndoCommand.java
@@ -3,6 +3,7 @@ package seedu.mark.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.mark.model.Model.PREDICATE_SHOW_ALL_BOOKMARKS;
 
+import seedu.mark.logic.commands.commandresult.CommandResult;
 import seedu.mark.logic.commands.exceptions.CommandException;
 import seedu.mark.model.Model;
 

--- a/src/main/java/seedu/mark/logic/commands/UndoCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/UndoCommand.java
@@ -8,7 +8,7 @@ import seedu.mark.logic.commands.exceptions.CommandException;
 import seedu.mark.model.Model;
 
 /**
- * Reverts the {@code model}'s mark to its previous state.
+ * Reverts the {@code model}'s Mark to its previous state.
  */
 public class UndoCommand extends Command {
     public static final String COMMAND_WORD = "undo";

--- a/src/main/java/seedu/mark/logic/parser/MarkParser.java
+++ b/src/main/java/seedu/mark/logic/parser/MarkParser.java
@@ -16,6 +16,8 @@ import seedu.mark.logic.commands.ExitCommand;
 import seedu.mark.logic.commands.FindCommand;
 import seedu.mark.logic.commands.HelpCommand;
 import seedu.mark.logic.commands.ListCommand;
+import seedu.mark.logic.commands.RedoCommand;
+import seedu.mark.logic.commands.UndoCommand;
 import seedu.mark.logic.parser.exceptions.ParseException;
 
 /**
@@ -68,6 +70,12 @@ public class MarkParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case UndoCommand.COMMAND_WORD:
+            return new UndoCommand();
+
+        case RedoCommand.COMMAND_WORD:
+            return new RedoCommand();
 
         case AddFolderCommand.COMMAND_WORD:
             return new AddFolderCommandParser().parse(arguments);

--- a/src/main/java/seedu/mark/model/Model.java
+++ b/src/main/java/seedu/mark/model/Model.java
@@ -91,27 +91,27 @@ public interface Model {
     boolean hasFolder(Folder folder);
 
     /**
-     * Returns true if the model has previous mark states to restore.
+     * Returns true if the model has previous Mark states to restore.
      */
     boolean canUndoMark();
 
     /**
-     * Returns true if the model has undone mark states to restore.
+     * Returns true if the model has undone Mark states to restore.
      */
     boolean canRedoMark();
 
     /**
-     * Restores the model's mark to its previous state.
+     * Restores the model's Mark to its previous state.
      */
     void undoMark();
 
     /**
-     * Restores the model's mark to its previously undone state.
+     * Restores the model's Mark to its previously undone state.
      */
     void redoMark();
 
     /**
-     * Saves the current mark state for undo/redo.
+     * Saves the current Mark state for undo/redo.
      */
     void saveMark();
 }

--- a/src/main/java/seedu/mark/model/Model.java
+++ b/src/main/java/seedu/mark/model/Model.java
@@ -89,4 +89,29 @@ public interface Model {
     void addFolder(Folder folder, Folder parentFolder);
 
     boolean hasFolder(Folder folder);
+
+    /**
+     * Returns true if the model has previous mark states to restore.
+     */
+    boolean canUndoMark();
+
+    /**
+     * Returns true if the model has undone mark states to restore.
+     */
+    boolean canRedoMark();
+
+    /**
+     * Restores the model's mark to its previous state.
+     */
+    void undoMark();
+
+    /**
+     * Restores the model's mark to its previously undone state.
+     */
+    void redoMark();
+
+    /**
+     * Saves the current mark state for undo/redo.
+     */
+    void commitMark();
 }

--- a/src/main/java/seedu/mark/model/Model.java
+++ b/src/main/java/seedu/mark/model/Model.java
@@ -113,5 +113,5 @@ public interface Model {
     /**
      * Saves the current mark state for undo/redo.
      */
-    void commitMark();
+    void saveMark();
 }

--- a/src/main/java/seedu/mark/model/ModelManager.java
+++ b/src/main/java/seedu/mark/model/ModelManager.java
@@ -113,16 +113,15 @@ public class ModelManager implements Model {
         versionedMark.setBookmark(target, editedBookmark);
     }
 
-
     @Override
     public void addFolder(Folder folder, Folder parentFolder) {
         requireAllNonNull(folder, parentFolder);
-        mark.addFolder(folder, parentFolder);
+        versionedMark.addFolder(folder, parentFolder);
     }
 
     @Override
     public boolean hasFolder(Folder folder) {
-        return mark.hasFolder(folder);
+        return versionedMark.hasFolder(folder);
     }
 
     //=========== Filtered Bookmark List Accessors =============================================================

--- a/src/main/java/seedu/mark/model/ModelManager.java
+++ b/src/main/java/seedu/mark/model/ModelManager.java
@@ -165,8 +165,8 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void commitMark() {
-        versionedMark.commit();
+    public void saveMark() {
+        versionedMark.save();
     }
 
     @Override

--- a/src/main/java/seedu/mark/model/ModelManager.java
+++ b/src/main/java/seedu/mark/model/ModelManager.java
@@ -20,7 +20,7 @@ import seedu.mark.model.bookmark.Folder;
 public class ModelManager implements Model {
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
 
-    private final Mark mark;
+    private final VersionedMark versionedMark;
     private final UserPrefs userPrefs;
     private final FilteredList<Bookmark> filteredBookmarks;
 
@@ -33,9 +33,9 @@ public class ModelManager implements Model {
 
         logger.fine("Initializing with Mark: " + mark + " and user prefs " + userPrefs);
 
-        this.mark = new Mark(mark);
+        versionedMark = new VersionedMark(mark);
         this.userPrefs = new UserPrefs(userPrefs);
-        filteredBookmarks = new FilteredList<>(this.mark.getBookmarkList());
+        filteredBookmarks = new FilteredList<>(versionedMark.getBookmarkList());
     }
 
     public ModelManager() {
@@ -81,28 +81,28 @@ public class ModelManager implements Model {
 
     @Override
     public void setMark(ReadOnlyMark mark) {
-        this.mark.resetData(mark);
+        versionedMark.resetData(mark);
     }
 
     @Override
     public ReadOnlyMark getMark() {
-        return mark;
+        return versionedMark;
     }
 
     @Override
     public boolean hasBookmark(Bookmark bookmark) {
         requireNonNull(bookmark);
-        return mark.hasBookmark(bookmark);
+        return versionedMark.hasBookmark(bookmark);
     }
 
     @Override
     public void deleteBookmark(Bookmark target) {
-        mark.removeBookmark(target);
+        versionedMark.removeBookmark(target);
     }
 
     @Override
     public void addBookmark(Bookmark bookmark) {
-        mark.addBookmark(bookmark);
+        versionedMark.addBookmark(bookmark);
         updateFilteredBookmarkList(PREDICATE_SHOW_ALL_BOOKMARKS);
     }
 
@@ -110,7 +110,7 @@ public class ModelManager implements Model {
     public void setBookmark(Bookmark target, Bookmark editedBookmark) {
         requireAllNonNull(target, editedBookmark);
 
-        mark.setBookmark(target, editedBookmark);
+        versionedMark.setBookmark(target, editedBookmark);
     }
 
 
@@ -142,6 +142,33 @@ public class ModelManager implements Model {
         filteredBookmarks.setPredicate(predicate);
     }
 
+    //=========== Undo/Redo =================================================================================
+
+    @Override
+    public boolean canUndoMark() {
+        return versionedMark.canUndo();
+    }
+
+    @Override
+    public boolean canRedoMark() {
+        return versionedMark.canRedo();
+    }
+
+    @Override
+    public void undoMark() {
+        versionedMark.undo();
+    }
+
+    @Override
+    public void redoMark() {
+        versionedMark.redo();
+    }
+
+    @Override
+    public void commitMark() {
+        versionedMark.commit();
+    }
+
     @Override
     public boolean equals(Object obj) {
         // short circuit if same object
@@ -156,7 +183,7 @@ public class ModelManager implements Model {
 
         // state check
         ModelManager other = (ModelManager) obj;
-        return mark.equals(other.mark)
+        return versionedMark.equals(other.versionedMark)
                 && userPrefs.equals(other.userPrefs)
                 && filteredBookmarks.equals(other.filteredBookmarks);
     }

--- a/src/main/java/seedu/mark/model/VersionedMark.java
+++ b/src/main/java/seedu/mark/model/VersionedMark.java
@@ -34,7 +34,7 @@ public class VersionedMark extends Mark {
     }
 
     /**
-     * Restores the mark to its previous state.
+     * Restores the Mark to its previous state.
      */
     public void undo() {
         if (!canUndo()) {
@@ -45,7 +45,7 @@ public class VersionedMark extends Mark {
     }
 
     /**
-     * Restores the mark to its previously undone state.
+     * Restores the Mark to its previously undone state.
      */
     public void redo() {
         if (!canRedo()) {
@@ -56,14 +56,14 @@ public class VersionedMark extends Mark {
     }
 
     /**
-     * Returns true if {@code undo()} has mark states to undo.
+     * Returns true if {@code undo()} has Mark states to undo.
      */
     public boolean canUndo() {
         return currentStatePointer > 0;
     }
 
     /**
-     * Returns true if {@code redo()} has mark states to redo.
+     * Returns true if {@code redo()} has Mark states to redo.
      */
     public boolean canRedo() {
         return currentStatePointer < markStateList.size() - 1;

--- a/src/main/java/seedu/mark/model/VersionedMark.java
+++ b/src/main/java/seedu/mark/model/VersionedMark.java
@@ -1,0 +1,91 @@
+package seedu.mark.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@code Mark} that keeps track of its own history.
+ */
+public class VersionedMark extends Mark {
+
+    private final List<ReadOnlyMark> markStateList;
+    private int currentStatePointer;
+
+    public VersionedMark(ReadOnlyMark initialState) {
+        super(initialState);
+
+        markStateList = new ArrayList<>();
+        markStateList.add(new Mark(initialState));
+        currentStatePointer = 0;
+    }
+
+    /**
+     * Appends a copy of the current {@code Mark} state to the end of the state list.
+     * Undone states after the current state pointer are removed from the state list.
+     */
+    public void commit() {
+        removeStatesAfterCurrentPointer();
+        markStateList.add(new Mark(this));
+        currentStatePointer++;
+    }
+
+    private void removeStatesAfterCurrentPointer() {
+        markStateList.subList(currentStatePointer + 1, markStateList.size()).clear();
+    }
+
+    /**
+     * Restores the mark to its previous state.
+     */
+    public void undo() {
+        if (!canUndo()) {
+            throw new RuntimeException("Current state pointer at start of markState list, unable to undo.");
+        }
+        currentStatePointer--;
+        resetData(markStateList.get(currentStatePointer));
+    }
+
+    /**
+     * Restores the mark to its previously undone state.
+     */
+    public void redo() {
+        if (!canRedo()) {
+            throw new RuntimeException("Current state pointer at end of markState list, unable to redo.");
+        }
+        currentStatePointer++;
+        resetData(markStateList.get(currentStatePointer));
+    }
+
+    /**
+     * Returns true if {@code undo()} has mark states to undo.
+     */
+    public boolean canUndo() {
+        return currentStatePointer > 0;
+    }
+
+    /**
+     * Returns true if {@code redo()} has mark states to redo.
+     */
+    public boolean canRedo() {
+        return currentStatePointer < markStateList.size() - 1;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof VersionedMark)) {
+            return false;
+        }
+
+        VersionedMark otherVersionedMark = (VersionedMark) other;
+
+        // state check
+        return super.equals(otherVersionedMark)
+                && markStateList.equals(otherVersionedMark.markStateList)
+                && currentStatePointer == otherVersionedMark.currentStatePointer;
+    }
+}

--- a/src/main/java/seedu/mark/model/VersionedMark.java
+++ b/src/main/java/seedu/mark/model/VersionedMark.java
@@ -23,7 +23,7 @@ public class VersionedMark extends Mark {
      * Appends a copy of the current {@code Mark} state to the end of the state list.
      * Undone states after the current state pointer are removed from the state list.
      */
-    public void commit() {
+    public void save() {
         removeStatesAfterCurrentPointer();
         markStateList.add(new Mark(this));
         currentStatePointer++;
@@ -38,7 +38,7 @@ public class VersionedMark extends Mark {
      */
     public void undo() {
         if (!canUndo()) {
-            throw new CannotUndoException();
+            throw new CannotUndoMarkException();
         }
         currentStatePointer--;
         resetData(markStateList.get(currentStatePointer));
@@ -49,7 +49,7 @@ public class VersionedMark extends Mark {
      */
     public void redo() {
         if (!canRedo()) {
-            throw new CannotRedoException();
+            throw new CannotRedoMarkException();
         }
         currentStatePointer++;
         resetData(markStateList.get(currentStatePointer));
@@ -92,18 +92,18 @@ public class VersionedMark extends Mark {
     /**
      * Thrown when trying to {@code undo()} but can't.
      */
-    private static class CannotUndoException extends RuntimeException {
-        private CannotUndoException() {
-            super("Current state pointer at start of addressBookState list, unable to undo.");
+    private static class CannotUndoMarkException extends RuntimeException {
+        private CannotUndoMarkException() {
+            super("Current state pointer at start of markState list, unable to undo.");
         }
     }
 
     /**
      * Thrown when trying to {@code redo()} but can't.
      */
-    private static class CannotRedoException extends RuntimeException {
-        private CannotRedoException() {
-            super("Current state pointer at end of addressBookState list, unable to redo.");
+    private static class CannotRedoMarkException extends RuntimeException {
+        private CannotRedoMarkException() {
+            super("Current state pointer at end of markState list, unable to redo.");
         }
     }
 }

--- a/src/main/java/seedu/mark/model/VersionedMark.java
+++ b/src/main/java/seedu/mark/model/VersionedMark.java
@@ -38,7 +38,7 @@ public class VersionedMark extends Mark {
      */
     public void undo() {
         if (!canUndo()) {
-            throw new RuntimeException("Current state pointer at start of markState list, unable to undo.");
+            throw new CannotUndoException();
         }
         currentStatePointer--;
         resetData(markStateList.get(currentStatePointer));
@@ -49,7 +49,7 @@ public class VersionedMark extends Mark {
      */
     public void redo() {
         if (!canRedo()) {
-            throw new RuntimeException("Current state pointer at end of markState list, unable to redo.");
+            throw new CannotRedoException();
         }
         currentStatePointer++;
         resetData(markStateList.get(currentStatePointer));
@@ -87,5 +87,23 @@ public class VersionedMark extends Mark {
         return super.equals(otherVersionedMark)
                 && markStateList.equals(otherVersionedMark.markStateList)
                 && currentStatePointer == otherVersionedMark.currentStatePointer;
+    }
+
+    /**
+     * Thrown when trying to {@code undo()} but can't.
+     */
+    private static class CannotUndoException extends RuntimeException {
+        private CannotUndoException() {
+            super("Current state pointer at start of addressBookState list, unable to undo.");
+        }
+    }
+
+    /**
+     * Thrown when trying to {@code redo()} but can't.
+     */
+    private static class CannotRedoException extends RuntimeException {
+        private CannotRedoException() {
+            super("Current state pointer at end of addressBookState list, unable to redo.");
+        }
     }
 }

--- a/src/main/java/seedu/mark/ui/FolderStructureTreeView.java
+++ b/src/main/java/seedu/mark/ui/FolderStructureTreeView.java
@@ -42,9 +42,6 @@ public class FolderStructureTreeView extends UiPart<Region> {
         populateTreeWithBookmarks();
         bookmarks.addListener((ListChangeListener<? super Bookmark>) change -> {
             while (change.next()) {
-                for (TreeItem<String> oldBookmarkTreeItem: bookmarkTreeItems) {
-                    oldBookmarkTreeItem.getParent().getChildren().remove(oldBookmarkTreeItem);
-                }
                 populateTreeWithBookmarks();
             }
         });
@@ -68,10 +65,17 @@ public class FolderStructureTreeView extends UiPart<Region> {
         }
         subfolders.addListener((ListChangeListener<? super FolderStructure>) change -> {
             while (change.next()) {
+                for (FolderStructure oldFolderStructure : change.getRemoved()) {
+                    TreeItem<String> oldFolderTreeItem = mapOfFolderToTreeItem.get(oldFolderStructure.getFolder());
+                    oldFolderTreeItem.getParent().getChildren().remove(oldFolderTreeItem);
+                    mapOfFolderToTreeItem.remove(oldFolderStructure.getFolder());
+                    populateTreeWithBookmarks();
+                }
                 for (FolderStructure newFolderStructure : change.getAddedSubList()) {
                     TreeItem<String> newBuilt = buildTree(newFolderStructure);
                     mapOfFolderToTreeItem.put(newFolderStructure.getFolder(), newBuilt);
                     built.getChildren().add(newBuilt);
+                    populateTreeWithBookmarks();
                 }
             }
         });
@@ -82,6 +86,9 @@ public class FolderStructureTreeView extends UiPart<Region> {
      * Populates the folder tree with bookmarks.
      */
     private void populateTreeWithBookmarks() {
+        for (TreeItem<String> oldBookmarkTreeItem: bookmarkTreeItems) {
+            oldBookmarkTreeItem.getParent().getChildren().remove(oldBookmarkTreeItem);
+        }
         bookmarkTreeItems = new ArrayList<>();
         for (Bookmark bookmark: bookmarks) {
             // if the folder is not found, we default it to the root

--- a/src/test/java/seedu/mark/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/mark/logic/LogicManagerTest.java
@@ -88,6 +88,7 @@ public class LogicManagerTest {
         Bookmark expectedBookmark = new BookmarkBuilder(AMY).withTags().build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addBookmark(expectedBookmark);
+        expectedModel.commitMark();
         String expectedMessage = LogicManager.FILE_OPS_ERROR_MESSAGE + DUMMY_IO_EXCEPTION;
         assertCommandFailure(addCommand, CommandException.class, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/mark/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/mark/logic/LogicManagerTest.java
@@ -88,7 +88,7 @@ public class LogicManagerTest {
         Bookmark expectedBookmark = new BookmarkBuilder(AMY).withTags().build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addBookmark(expectedBookmark);
-        expectedModel.commitMark();
+        expectedModel.saveMark();
         String expectedMessage = LogicManager.FILE_OPS_ERROR_MESSAGE + DUMMY_IO_EXCEPTION;
         assertCommandFailure(addCommand, CommandException.class, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/mark/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/mark/logic/commands/AddCommandIntegrationTest.java
@@ -31,6 +31,7 @@ public class AddCommandIntegrationTest {
 
         Model expectedModel = new ModelManager(model.getMark(), new UserPrefs());
         expectedModel.addBookmark(validBookmark);
+        expectedModel.commitMark();
 
         assertCommandSuccess(new AddCommand(validBookmark), model,
                 String.format(AddCommand.MESSAGE_SUCCESS, validBookmark), expectedModel);

--- a/src/test/java/seedu/mark/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/mark/logic/commands/AddCommandIntegrationTest.java
@@ -31,7 +31,7 @@ public class AddCommandIntegrationTest {
 
         Model expectedModel = new ModelManager(model.getMark(), new UserPrefs());
         expectedModel.addBookmark(validBookmark);
-        expectedModel.commitMark();
+        expectedModel.saveMark();
 
         assertCommandSuccess(new AddCommand(validBookmark), model,
                 String.format(AddCommand.MESSAGE_SUCCESS, validBookmark), expectedModel);

--- a/src/test/java/seedu/mark/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/AddCommandTest.java
@@ -109,7 +109,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void commitMark() {
+        public void saveMark() {
             // called by {@code AddCommand#execute()}
         }
 

--- a/src/test/java/seedu/mark/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/AddCommandTest.java
@@ -109,6 +109,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void commitMark() {
+            // called by {@code AddCommand#execute()}
+        }
+
+        @Override
         public ReadOnlyMark getMark() {
             return new Mark();
         }

--- a/src/test/java/seedu/mark/logic/commands/AddFolderCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/AddFolderCommandTest.java
@@ -133,5 +133,10 @@ public class AddFolderCommandTest {
             folderStructure.find(parentFolder == null ? Folder.ROOT_FOLDER : parentFolder)
                     .getSubfolders().add(new FolderStructure(folder, new ArrayList<>()));
         }
+
+        @Override
+        public void saveMark() {
+            // called by {@code AddFolderCommand#execute()}
+        }
     }
 }

--- a/src/test/java/seedu/mark/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/ClearCommandTest.java
@@ -16,6 +16,7 @@ public class ClearCommandTest {
     public void execute_emptyMark_success() {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
+        expectedModel.commitMark();
 
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }
@@ -25,6 +26,7 @@ public class ClearCommandTest {
         Model model = new ModelManager(getTypicalMark(), new UserPrefs());
         Model expectedModel = new ModelManager(getTypicalMark(), new UserPrefs());
         expectedModel.setMark(new Mark());
+        expectedModel.commitMark();
 
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }

--- a/src/test/java/seedu/mark/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/ClearCommandTest.java
@@ -16,7 +16,7 @@ public class ClearCommandTest {
     public void execute_emptyMark_success() {
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
-        expectedModel.commitMark();
+        expectedModel.saveMark();
 
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }
@@ -26,7 +26,7 @@ public class ClearCommandTest {
         Model model = new ModelManager(getTypicalMark(), new UserPrefs());
         Model expectedModel = new ModelManager(getTypicalMark(), new UserPrefs());
         expectedModel.setMark(new Mark());
-        expectedModel.commitMark();
+        expectedModel.saveMark();
 
         assertCommandSuccess(new ClearCommand(), model, ClearCommand.MESSAGE_SUCCESS, expectedModel);
     }

--- a/src/test/java/seedu/mark/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/mark/logic/commands/CommandTestUtil.java
@@ -9,6 +9,7 @@ import static seedu.mark.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.mark.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.mark.logic.parser.CliSyntax.PREFIX_URL;
 import static seedu.mark.testutil.Assert.assertThrows;
+import static seedu.mark.testutil.TypicalIndexes.INDEX_FIRST_BOOKMARK;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -128,6 +129,27 @@ public class CommandTestUtil {
         model.updateFilteredBookmarkList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
         assertEquals(1, model.getFilteredBookmarkList().size());
+    }
+
+    /**
+     * Deletes the bookmark at the given {@code targetIndex} in the {@code model}'s mark.
+     */
+    public static void deleteBookmarkAtIndex(Model model, Index targetIndex) {
+        int initialSize = model.getFilteredBookmarkList().size();
+        assertTrue(targetIndex.getZeroBased() < initialSize);
+
+        Bookmark bookmarkToDelete = model.getFilteredBookmarkList().get(targetIndex.getZeroBased());
+        model.deleteBookmark(bookmarkToDelete);
+        model.saveMark();
+
+        assertEquals(initialSize - 1, model.getFilteredBookmarkList().size());
+    }
+
+    /**
+     * Deletes the first bookmark in {@code model}'s mark.
+     */
+    public static void deleteFirstBookmark(Model model) {
+        deleteBookmarkAtIndex(model, INDEX_FIRST_BOOKMARK);
     }
 
 }

--- a/src/test/java/seedu/mark/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/DeleteCommandTest.java
@@ -35,6 +35,7 @@ public class DeleteCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getMark(), new UserPrefs());
         expectedModel.deleteBookmark(bookmarkToDelete);
+        expectedModel.commitMark();
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
@@ -58,6 +59,7 @@ public class DeleteCommandTest {
 
         Model expectedModel = new ModelManager(model.getMark(), new UserPrefs());
         expectedModel.deleteBookmark(bookmarkToDelete);
+        expectedModel.commitMark();
         showNoBookmark(expectedModel);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/mark/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/DeleteCommandTest.java
@@ -35,7 +35,7 @@ public class DeleteCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getMark(), new UserPrefs());
         expectedModel.deleteBookmark(bookmarkToDelete);
-        expectedModel.commitMark();
+        expectedModel.saveMark();
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
@@ -59,7 +59,7 @@ public class DeleteCommandTest {
 
         Model expectedModel = new ModelManager(model.getMark(), new UserPrefs());
         expectedModel.deleteBookmark(bookmarkToDelete);
-        expectedModel.commitMark();
+        expectedModel.saveMark();
         showNoBookmark(expectedModel);
 
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);

--- a/src/test/java/seedu/mark/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/EditCommandTest.java
@@ -42,6 +42,7 @@ public class EditCommandTest {
 
         Model expectedModel = new ModelManager(new Mark(model.getMark()), new UserPrefs());
         expectedModel.setBookmark(model.getFilteredBookmarkList().get(0), editedBookmark);
+        expectedModel.commitMark();
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -63,6 +64,7 @@ public class EditCommandTest {
 
         Model expectedModel = new ModelManager(new Mark(model.getMark()), new UserPrefs());
         expectedModel.setBookmark(lastBookmark, editedBookmark);
+        expectedModel.commitMark();
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -75,6 +77,7 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_BOOKMARK_SUCCESS, editedBookmark);
 
         Model expectedModel = new ModelManager(new Mark(model.getMark()), new UserPrefs());
+        expectedModel.commitMark();
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -92,6 +95,7 @@ public class EditCommandTest {
 
         Model expectedModel = new ModelManager(new Mark(model.getMark()), new UserPrefs());
         expectedModel.setBookmark(model.getFilteredBookmarkList().get(0), editedBookmark);
+        expectedModel.commitMark();
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/mark/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/EditCommandTest.java
@@ -42,7 +42,7 @@ public class EditCommandTest {
 
         Model expectedModel = new ModelManager(new Mark(model.getMark()), new UserPrefs());
         expectedModel.setBookmark(model.getFilteredBookmarkList().get(0), editedBookmark);
-        expectedModel.commitMark();
+        expectedModel.saveMark();
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -64,7 +64,7 @@ public class EditCommandTest {
 
         Model expectedModel = new ModelManager(new Mark(model.getMark()), new UserPrefs());
         expectedModel.setBookmark(lastBookmark, editedBookmark);
-        expectedModel.commitMark();
+        expectedModel.saveMark();
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -77,7 +77,7 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_BOOKMARK_SUCCESS, editedBookmark);
 
         Model expectedModel = new ModelManager(new Mark(model.getMark()), new UserPrefs());
-        expectedModel.commitMark();
+        expectedModel.saveMark();
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }
@@ -95,7 +95,7 @@ public class EditCommandTest {
 
         Model expectedModel = new ModelManager(new Mark(model.getMark()), new UserPrefs());
         expectedModel.setBookmark(model.getFilteredBookmarkList().get(0), editedBookmark);
-        expectedModel.commitMark();
+        expectedModel.saveMark();
 
         assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/mark/logic/commands/RedoCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/RedoCommandTest.java
@@ -1,0 +1,41 @@
+package seedu.mark.logic.commands;
+
+import static seedu.mark.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.mark.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.mark.logic.commands.CommandTestUtil.deleteFirstBookmark;
+import static seedu.mark.testutil.TypicalBookmarks.getTypicalMark;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.mark.model.Model;
+import seedu.mark.model.ModelManager;
+import seedu.mark.model.UserPrefs;
+
+public class RedoCommandTest {
+    private Model model = new ModelManager(getTypicalMark(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalMark(), new UserPrefs());
+
+    @Test
+    public void execute() {
+        deleteFirstBookmark(model);
+        deleteFirstBookmark(model);
+        model.undoMark();
+        model.undoMark();
+
+        deleteFirstBookmark(expectedModel);
+        deleteFirstBookmark(expectedModel);
+        expectedModel.undoMark();
+        expectedModel.undoMark();
+
+        // Two redoable Mark states
+        expectedModel.redoMark();
+        assertCommandSuccess(new RedoCommand(), model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+
+        // Single redoable Mark state
+        expectedModel.redoMark();
+        assertCommandSuccess(new RedoCommand(), model, RedoCommand.MESSAGE_SUCCESS, expectedModel);
+
+        // No redoable Mark state
+        assertCommandFailure(new RedoCommand(), model, RedoCommand.MESSAGE_FAILURE);
+    }
+}

--- a/src/test/java/seedu/mark/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/UndoCommandTest.java
@@ -1,0 +1,37 @@
+package seedu.mark.logic.commands;
+
+import static seedu.mark.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.mark.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.mark.logic.commands.CommandTestUtil.deleteFirstBookmark;
+import static seedu.mark.testutil.TypicalBookmarks.getTypicalMark;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.mark.model.Model;
+import seedu.mark.model.ModelManager;
+import seedu.mark.model.UserPrefs;
+
+public class UndoCommandTest {
+    private Model model = new ModelManager(getTypicalMark(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalMark(), new UserPrefs());
+
+    @Test
+    public void execute() {
+        deleteFirstBookmark(model);
+        deleteFirstBookmark(expectedModel);
+
+        deleteFirstBookmark(model);
+        deleteFirstBookmark(expectedModel);
+
+        // Two undoable Mark states
+        expectedModel.undoMark();
+        assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+
+        // Single undoable Mark state
+        expectedModel.undoMark();
+        assertCommandSuccess(new UndoCommand(), model, UndoCommand.MESSAGE_SUCCESS, expectedModel);
+
+        // No undoable Mark state
+        assertCommandFailure(new UndoCommand(), model, UndoCommand.MESSAGE_FAILURE);
+    }
+}

--- a/src/test/java/seedu/mark/logic/parser/MarkParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/MarkParserTest.java
@@ -23,6 +23,8 @@ import seedu.mark.logic.commands.ExitCommand;
 import seedu.mark.logic.commands.FindCommand;
 import seedu.mark.logic.commands.HelpCommand;
 import seedu.mark.logic.commands.ListCommand;
+import seedu.mark.logic.commands.RedoCommand;
+import seedu.mark.logic.commands.UndoCommand;
 import seedu.mark.logic.parser.exceptions.ParseException;
 import seedu.mark.model.bookmark.Bookmark;
 import seedu.mark.model.bookmark.Folder;
@@ -95,6 +97,18 @@ public class MarkParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_undo() throws Exception {
+        assertTrue(parser.parseCommand(UndoCommand.COMMAND_WORD) instanceof UndoCommand);
+        assertTrue(parser.parseCommand(UndoCommand.COMMAND_WORD + " 3") instanceof UndoCommand);
+    }
+
+    @Test
+    public void parseCommand_redo() throws Exception {
+        assertTrue(parser.parseCommand(RedoCommand.COMMAND_WORD) instanceof RedoCommand);
+        assertTrue(parser.parseCommand(RedoCommand.COMMAND_WORD + " 3") instanceof RedoCommand);
     }
 
     @Test

--- a/src/test/java/seedu/mark/model/ModelStub.java
+++ b/src/test/java/seedu/mark/model/ModelStub.java
@@ -114,7 +114,7 @@ public class ModelStub implements Model {
     }
 
     @Override
-    public void commitMark() {
+    public void saveMark() {
         throw new AssertionError("This method should not be called.");
     }
 }

--- a/src/test/java/seedu/mark/model/ModelStub.java
+++ b/src/test/java/seedu/mark/model/ModelStub.java
@@ -92,4 +92,29 @@ public class ModelStub implements Model {
     public boolean hasFolder(Folder folder) {
         throw new AssertionError("This method should not be called.");
     }
+
+    @Override
+    public boolean canUndoMark() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean canRedoMark() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void undoMark() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void redoMark() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void commitMark() {
+        throw new AssertionError("This method should not be called.");
+    }
 }


### PR DESCRIPTION
Notes:
- `VersionedMark` is a subclass of `Mark` and it supports all the functionalities of `Mark` and additionally it stores a list of states of `Mark` and supports `undo` and `redo`.
- In the `ModelManager`, `Mark` is replaced with `VersionedMark` . 
- Undoable commands now include: `add`, `delete`, `clear`, `edit`, and 'folder'. Hence, in their respective `execute()` methods, `saveMark()` is called.

Future extensions (probably in v1.3):
- Currently, command history is not stored (only a list of states are stored in `VersionedMark` class). If possible, we can also store command history and display to users what command they are undoing/redoing.
- Undo multiple commands (e.g. `undo 2`)
- Support `undo` and `redo` even the application is closed (to implement this, history states of `Mark` must be stored somewhere and there must be a list of history states to be stored. 

Closes #29 