### PR TITLE
Set bookmark folders to ROOT during import

### DIFF
--- a/src/main/java/seedu/mark/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/ImportCommand.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
 
+import javafx.collections.ObservableList;
 import seedu.mark.commons.core.LogsCenter;
 import seedu.mark.commons.exceptions.DataConversionException;
 import seedu.mark.logic.commands.exceptions.CommandException;
@@ -16,6 +17,7 @@ import seedu.mark.logic.commands.results.CommandResult;
 import seedu.mark.model.Model;
 import seedu.mark.model.ReadOnlyMark;
 import seedu.mark.model.bookmark.Bookmark;
+import seedu.mark.model.bookmark.Folder;
 import seedu.mark.model.folderstructure.FolderStructure;
 import seedu.mark.storage.JsonMarkStorage;
 import seedu.mark.storage.Storage;
@@ -136,11 +138,30 @@ public class ImportCommand extends Command {
         MarkImporter(Model model, ReadOnlyMark markToImport) {
             this.model = model;
             this.foldersToImport = markToImport.getFolderStructure();
-            for (Bookmark bookmark : markToImport.getBookmarkList()) {
+            processBookmarks(markToImport.getBookmarkList());
+        }
+
+        /**
+         * Returns copy of the given {@code Bookmark} with its folder set to
+         * {@code Folder.ROOT_FOLDER}.
+         */
+        public static Bookmark setToRootFolder(Bookmark bookmark) {
+            return new Bookmark(bookmark.getName(), bookmark.getUrl(), bookmark.getRemark(),
+                    Folder.ROOT_FOLDER, bookmark.getTags());
+        }
+
+        /**
+         * Classifies bookmarks from the given list based on whether they and/or
+         * their folders exist in the model.
+         */
+        private void processBookmarks(ObservableList<Bookmark> bookmarks) {
+            for (Bookmark bookmark : bookmarks) {
                 if (model.hasBookmark(bookmark)) {
                     this.existingBookmarks.add(bookmark);
-                } else {
+                } else if (model.hasFolder(bookmark.getFolder())) {
                     this.bookmarksToImport.add(bookmark);
+                } else {
+                    this.bookmarksToImport.add(setToRootFolder(bookmark));
                 }
             }
         }


### PR DESCRIPTION
* Only for bookmarks whose folders do not exist in Mark. If a bookmark's folder already exists, it is added to Mark without modification.
* Other changes
  * `ImportCommandTest`: Created a few static `Path`s to minimise human error when writing tests.

Addresses second item of #106.