### PR TITLE
WIP: Display raw user input for undo/redo

### DIFF
--- a/src/main/java/seedu/mark/logic/LogicManager.java
+++ b/src/main/java/seedu/mark/logic/LogicManager.java
@@ -47,6 +47,10 @@ public class LogicManager implements Logic {
         Command command = markParser.parseCommand(commandText);
         commandResult = command.execute(model, storage);
 
+        if (command.isUndoable()) {
+            model.saveMark(commandText);
+        }
+
         try {
             storage.saveMark(model.getMark());
         } catch (IOException ioe) {

--- a/src/main/java/seedu/mark/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/AddCommand.java
@@ -56,8 +56,12 @@ public class AddCommand extends Command {
 
         model.addBookmark(toAdd);
         model.applyAllTaggers();
-        model.saveMark(String.format(MESSAGE_SUCCESS, toAdd));
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+    }
+
+    @Override
+    public boolean isUndoable() {
+        return true;
     }
 
     @Override

--- a/src/main/java/seedu/mark/logic/commands/AddFolderCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/AddFolderCommand.java
@@ -55,11 +55,13 @@ public class AddFolderCommand extends Command {
         }
 
         model.addFolder(folder, parentFolder);
-        model.saveMark(String.format(MESSAGE_SUCCESS, folder));
-
         return new CommandResult(String.format(MESSAGE_SUCCESS, folder));
     }
 
+    @Override
+    public boolean isUndoable() {
+        return true;
+    }
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/seedu/mark/logic/commands/AddReminderCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/AddReminderCommand.java
@@ -71,8 +71,12 @@ public class AddReminderCommand extends Command {
         }
 
         model.addReminder(bookmarkToOpen, reminderToAdd);
-        model.saveMark(String.format(MESSAGE_SUCCESS, reminderToAdd));
         return new CommandResult(String.format(MESSAGE_SUCCESS, reminderToAdd));
+    }
+
+    @Override
+    public boolean isUndoable() {
+        return true;
     }
 
     @Override

--- a/src/main/java/seedu/mark/logic/commands/AutotagCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/AutotagCommand.java
@@ -45,8 +45,12 @@ public class AutotagCommand extends Command {
         model.addTagger(tagger);
         model.applyAllTaggers();
         // TODO: Don't save Mark if no taggers were actually applied
-        model.saveMark(String.format(MESSAGE_AUTOTAG_ADDED, tagger));
         return new CommandResult(String.format(MESSAGE_AUTOTAG_ADDED, tagger));
+    }
+
+    @Override
+    public boolean isUndoable() {
+        return true;
     }
 
     @Override

--- a/src/main/java/seedu/mark/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/ClearCommand.java
@@ -20,7 +20,11 @@ public class ClearCommand extends Command {
         requireAllNonNull(model, storage);
 
         model.setMark(new Mark());
-        model.saveMark(MESSAGE_SUCCESS);
         return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public boolean isUndoable() {
+        return true;
     }
 }

--- a/src/main/java/seedu/mark/logic/commands/Command.java
+++ b/src/main/java/seedu/mark/logic/commands/Command.java
@@ -19,4 +19,8 @@ public abstract class Command {
      * @throws CommandException If an error occurs during command execution.
      */
     public abstract CommandResult execute(Model model, Storage storage) throws CommandException;
+
+    public boolean isUndoable() {
+        return false;
+    }
 }

--- a/src/main/java/seedu/mark/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/DeleteCommand.java
@@ -44,8 +44,12 @@ public class DeleteCommand extends Command {
 
         Bookmark bookmarkToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteBookmark(bookmarkToDelete);
-        model.saveMark(String.format(MESSAGE_DELETE_BOOKMARK_SUCCESS, bookmarkToDelete));
         return new CommandResult(String.format(MESSAGE_DELETE_BOOKMARK_SUCCESS, bookmarkToDelete));
+    }
+
+    @Override
+    public boolean isUndoable() {
+        return true;
     }
 
     @Override

--- a/src/main/java/seedu/mark/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/EditCommand.java
@@ -86,7 +86,6 @@ public class EditCommand extends Command {
 
         model.setBookmark(bookmarkToEdit, editedBookmark);
         model.applyAllTaggers();
-        model.saveMark(String.format(MESSAGE_EDIT_BOOKMARK_SUCCESS, editedBookmark));
         model.updateFilteredBookmarkList(PREDICATE_SHOW_ALL_BOOKMARKS);
         return new CommandResult(String.format(MESSAGE_EDIT_BOOKMARK_SUCCESS, editedBookmark));
     }
@@ -106,6 +105,11 @@ public class EditCommand extends Command {
         Folder updatedFolder = editBookmarkDescriptor.getFolder().orElse(bookmarkToEdit.getFolder());
 
         return new Bookmark(updatedName, updatedUrl, updatedRemark, updatedFolder, updatedTags);
+    }
+
+    @Override
+    public boolean isUndoable() {
+        return true;
     }
 
     @Override

--- a/src/main/java/seedu/mark/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/ImportCommand.java
@@ -110,8 +110,12 @@ public class ImportCommand extends Command {
                     importer.getExistingBookmarksAsString())
                 : String.format(MESSAGE_IMPORT_SUCCESS, filePath);
 
-        model.saveMark(message);
         return new CommandResult(message);
+    }
+
+    @Override
+    public boolean isUndoable() {
+        return true;
     }
 
     /**

--- a/src/test/java/seedu/mark/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/mark/logic/LogicManagerTest.java
@@ -89,7 +89,7 @@ public class LogicManagerTest {
         ModelManager expectedModel = new ModelManager();
         String expectedMessage = LogicManager.FILE_OPS_ERROR_MESSAGE + DUMMY_IO_EXCEPTION;
         expectedModel.addBookmark(expectedBookmark);
-        expectedModel.saveMark(String.format(AddCommand.MESSAGE_SUCCESS, expectedBookmark));
+        expectedModel.saveMark(addCommand);
         assertCommandFailure(addCommand, CommandException.class, expectedMessage, expectedModel);
     }
 

--- a/src/test/java/seedu/mark/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/mark/logic/commands/AddCommandIntegrationTest.java
@@ -34,7 +34,6 @@ public class AddCommandIntegrationTest {
         Model expectedModel = new ModelManager(model.getMark(), new UserPrefs());
         String expectedMessage = String.format(AddCommand.MESSAGE_SUCCESS, validBookmark);
         expectedModel.addBookmark(validBookmark);
-        expectedModel.saveMark(expectedMessage);
 
         assertCommandSuccess(addCommand, model, new StorageStub(), expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/mark/logic/commands/AutotagCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/AutotagCommandTest.java
@@ -84,7 +84,6 @@ public class AutotagCommandTest {
 
         Model expectedModel = new ModelManager(getTypicalMark(), new UserPrefs());
         String expectedMessage = String.format(MESSAGE_AUTOTAG_ADDED, tagger);
-        expectedModel.saveMark(expectedMessage);
         assertCommandSuccess(command, model, storage, expectedMessage, expectedModel);
     }
 
@@ -100,7 +99,6 @@ public class AutotagCommandTest {
         Model expectedModel = new ModelManager(getTypicalMark(), new UserPrefs());
         String expectedMessage = String.format(MESSAGE_AUTOTAG_ADDED, tagger);
         expectedModel.setBookmark(ALICE, expectedBookmark1);
-        expectedModel.saveMark(expectedMessage);
 
         assertCommandSuccess(command, model, storage, expectedMessage, expectedModel);
     }
@@ -119,7 +117,6 @@ public class AutotagCommandTest {
         String expectedMessage = String.format(MESSAGE_AUTOTAG_ADDED, tagger);
         expectedModel.setBookmark(CARL, expectedBookmark1);
         expectedModel.setBookmark(FIONA, expectedBookmark2);
-        expectedModel.saveMark(expectedMessage);
 
         assertCommandSuccess(command, model, storage, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/mark/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/ClearCommandTest.java
@@ -18,7 +18,6 @@ public class ClearCommandTest {
         ClearCommand clearCommand = new ClearCommand();
         Model model = new ModelManager();
         Model expectedModel = new ModelManager();
-        expectedModel.saveMark(ClearCommand.MESSAGE_SUCCESS);
 
         assertCommandSuccess(clearCommand, model, new StorageStub(),
                 ClearCommand.MESSAGE_SUCCESS, expectedModel);
@@ -30,7 +29,6 @@ public class ClearCommandTest {
         Model model = new ModelManager(getTypicalMark(), new UserPrefs());
         Model expectedModel = new ModelManager(getTypicalMark(), new UserPrefs());
         expectedModel.setMark(new Mark());
-        expectedModel.saveMark(ClearCommand.MESSAGE_SUCCESS);
 
         assertCommandSuccess(clearCommand, model, new StorageStub(),
                 ClearCommand.MESSAGE_SUCCESS, expectedModel);

--- a/src/test/java/seedu/mark/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/mark/logic/commands/CommandTestUtil.java
@@ -154,7 +154,7 @@ public class CommandTestUtil {
 
         Bookmark bookmarkToDelete = model.getFilteredBookmarkList().get(targetIndex.getZeroBased());
         model.deleteBookmark(bookmarkToDelete);
-        model.saveMark(String.format(DeleteCommand.MESSAGE_DELETE_BOOKMARK_SUCCESS, bookmarkToDelete));
+        model.saveMark("delete 1");
 
         assertEquals(initialSize - 1, model.getFilteredBookmarkList().size());
     }

--- a/src/test/java/seedu/mark/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/DeleteCommandTest.java
@@ -36,7 +36,6 @@ public class DeleteCommandTest {
 
         ModelManager expectedModel = new ModelManager(model.getMark(), new UserPrefs());
         expectedModel.deleteBookmark(bookmarkToDelete);
-        expectedModel.saveMark(expectedMessage);
 
         assertCommandSuccess(deleteCommand, model, new StorageStub(), expectedMessage, expectedModel);
     }
@@ -61,7 +60,6 @@ public class DeleteCommandTest {
 
         Model expectedModel = new ModelManager(model.getMark(), new UserPrefs());
         expectedModel.deleteBookmark(bookmarkToDelete);
-        expectedModel.saveMark(expectedMessage);
         showNoBookmark(expectedModel);
 
         assertCommandSuccess(deleteCommand, model, new StorageStub(), expectedMessage, expectedModel);

--- a/src/test/java/seedu/mark/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/EditCommandTest.java
@@ -43,7 +43,6 @@ public class EditCommandTest {
 
         Model expectedModel = new ModelManager(new Mark(model.getMark()), new UserPrefs());
         expectedModel.setBookmark(model.getFilteredBookmarkList().get(0), editedBookmark);
-        expectedModel.saveMark(expectedMessage);
 
         assertCommandSuccess(editCommand, model, new StorageStub(), expectedMessage, expectedModel);
     }
@@ -65,7 +64,6 @@ public class EditCommandTest {
 
         Model expectedModel = new ModelManager(new Mark(model.getMark()), new UserPrefs());
         expectedModel.setBookmark(lastBookmark, editedBookmark);
-        expectedModel.saveMark(expectedMessage);
 
         assertCommandSuccess(editCommand, model, new StorageStub(), expectedMessage, expectedModel);
     }
@@ -78,7 +76,6 @@ public class EditCommandTest {
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_BOOKMARK_SUCCESS, editedBookmark);
 
         Model expectedModel = new ModelManager(new Mark(model.getMark()), new UserPrefs());
-        expectedModel.saveMark(expectedMessage);
 
         assertCommandSuccess(editCommand, model, new StorageStub(), expectedMessage, expectedModel);
     }
@@ -96,7 +93,6 @@ public class EditCommandTest {
 
         Model expectedModel = new ModelManager(new Mark(model.getMark()), new UserPrefs());
         expectedModel.setBookmark(model.getFilteredBookmarkList().get(0), editedBookmark);
-        expectedModel.saveMark(expectedMessage);
 
         assertCommandSuccess(editCommand, model, new StorageStub(), expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/mark/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/ImportCommandTest.java
@@ -98,7 +98,6 @@ public class ImportCommandTest {
         Mark expectedMark = new Mark();
         expectedMark.setBookmarks(setToRootFolder(getTypicalBookmarks())); // strip folders
         expectedModel.setMark(expectedMark);
-        expectedModel.saveMark(expectedMessage);
 
         assertCommandSuccess(command, model, storage, expectedMessage, expectedModel);
     }
@@ -148,7 +147,6 @@ public class ImportCommandTest {
         Mark expectedMark = new Mark();
         expectedMark.setBookmarks(setToRootFolder(getTypicalBookmarks()));
         expectedModel.setMark(expectedMark);
-        expectedModel.saveMark(expectedMessage);
 
         assertCommandSuccess(command, initialModel, storage, expectedMessage, expectedModel);
     }


### PR DESCRIPTION
I feel it is more intuitive for the users to see what commands they entered instead of the messages they saw for undo/redo. So the message will be sth like this: 
![image](https://user-images.githubusercontent.com/42093424/67386546-bf66e780-f5c7-11e9-9e96-ce303ec566e1.png)


Implementation notes:
- An isUndoable() method is created in Command class, default returns False. Every undoable command subclass will override this method and returns True
- In LogicManager#execute(), call Model#saveMark if the command is undoable, so there is no 
need to call saveMark() in each individual command#execute method and we can access the 
raw user input here and pass it to Model#saveMark(String record) as `record`
