### PR TITLE
Implement full autotag command

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -366,6 +366,7 @@ file `mark/data/bookmarks/myBookmarks.json`
 Imports bookmarks from the files `myBookmarks.json`, `nusBookmarks.json`,
 and `youtubeBookmarks.json`.
 
+[[Autotag-Command]]
 === Creating automatic tags: *`autotag`*
 
 Creates a tag that will be automatically applied to bookmarks which match
@@ -402,6 +403,23 @@ in the folder `NUS` but are not tagged with `academic` or `admin`.
 * `*autotag* Luminus u/luminus` +
  Creates an autotag that adds the tag `Luminus` to all bookmarks with URLs
 containing `luminus`.
+
+=== Deleting automatic tags: *`autotag-delete`*
+
+Deletes a previously created <<autotag, autotag>>.
+
+Format: `*autotag-delete* TAG_NAME`
+
+****
+* `TAG_NAME` should be the name of an existing autotag.
+****
+
+Example:
+
+* `*autotag-delete* Quiz` +
+ Deletes the autotag that would have tagged bookmarks that match its conditions
+with the tag `Quiz`. No existing tags are removed, but new and edited bookmarks
+will no longer be automatically tagged with `Quiz`.
 
 === Saving offline Readable copies of bookmarked website: *`cache`*
 
@@ -788,6 +806,10 @@ _{ more coming soon }_
 
 == Glossary
 This glossary aims to provide a definition for the special vocabulary used in this user guide.
+
+[[autotag]] Autotag::
+A tag that is automatically applied to bookmarks based on certain conditions. These conditions
+are specified when the autotag is created. Refer to <<Autotag-Command>> for details about how to use autotags.
 
 [[offline]] Offline::
 Refers to files stored locally on the computer.

--- a/src/main/java/seedu/mark/logic/commands/AutotagCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/AutotagCommand.java
@@ -21,12 +21,13 @@ public class AutotagCommand extends Command {
             + ": Creates an automatic tagger that tags bookmarks which match the given conditions. At least one "
             + "condition must be specified.\n"
             + "Parameters: TAG_NAME [n/NAME_KEYWORD]... [u/URL_KEYWORD]... "
-            + "[nn/NOT_NAME_KEYWORD]... [nu/NOT_URL_KEYWORD]...\n"
-            + "Example: " + COMMAND_WORD + " Quiz u/luminus.nus.edu.sg u/quiz nu/attempt";
+            + "[f/FOLDER]... [nn/NOT_NAME_KEYWORD]... [nu/NOT_URL_KEYWORD]... [nf/NOT_FOLDER]\n"
+            + "Example: " + COMMAND_WORD + " Quiz u/luminus.nus.edu.sg u/quiz nu/attempt f/AY1920";
 
     public static final String MESSAGE_AUTOTAG_ADDED = "An autotag was added successfully: %1$s";
     public static final String MESSAGE_AUTOTAG_EXISTS = "An autotag with this name already exists: %1$s";
-    public static final String MESSAGE_NO_CONDITION_SPECIFIED = "At least one name or URL condition must be specified";
+    public static final String MESSAGE_NO_CONDITION_SPECIFIED = "At least one name, URL, or folder condition "
+            + "must be specified";
 
     private final SelectiveBookmarkTagger tagger;
 

--- a/src/main/java/seedu/mark/logic/commands/AutotagCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/AutotagCommand.java
@@ -46,8 +46,9 @@ public class AutotagCommand extends Command {
         model.addTagger(tagger);
         model.applyAllTaggers();
         // TODO: Don't save Mark if no taggers were actually applied
-        model.saveMark(String.format(MESSAGE_AUTOTAG_ADDED, tagger));
-        return new CommandResult(String.format(MESSAGE_AUTOTAG_ADDED, tagger));
+        String resultMessage = String.format(MESSAGE_AUTOTAG_ADDED, tagger);
+        model.saveMark(resultMessage);
+        return new CommandResult(resultMessage);
     }
 
     @Override

--- a/src/main/java/seedu/mark/logic/commands/AutotagCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/AutotagCommand.java
@@ -28,6 +28,8 @@ public class AutotagCommand extends Command {
     public static final String MESSAGE_AUTOTAG_EXISTS = "An autotag with this name already exists: %1$s";
     public static final String MESSAGE_NO_CONDITION_SPECIFIED = "At least one name, URL, or folder condition "
             + "must be specified";
+    public static final String MESSAGE_CONDITION_EMPTY = "Conditions cannot be blank. E.g. the empty condition "
+            + "u/ is invalid";
 
     private final SelectiveBookmarkTagger tagger;
 

--- a/src/main/java/seedu/mark/logic/commands/AutotagCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/AutotagCommand.java
@@ -21,7 +21,7 @@ public class AutotagCommand extends Command {
             + ": Creates an automatic tagger that tags bookmarks which match the given conditions. At least one "
             + "condition must be specified.\n"
             + "Parameters: TAG_NAME [n/NAME_KEYWORD]... [u/URL_KEYWORD]... "
-            + "[f/FOLDER]... [nn/NOT_NAME_KEYWORD]... [nu/NOT_URL_KEYWORD]... [nf/NOT_FOLDER]\n"
+            + "[f/FOLDER]... [nn/NOT_NAME_KEYWORD]... [nu/NOT_URL_KEYWORD]... [nf/NOT_FOLDER]...\n"
             + "Example: " + COMMAND_WORD + " Quiz u/luminus.nus.edu.sg u/quiz nu/attempt f/AY1920";
 
     public static final String MESSAGE_AUTOTAG_ADDED = "An autotag was added successfully: %1$s";

--- a/src/main/java/seedu/mark/logic/commands/AutotagDeleteCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/AutotagDeleteCommand.java
@@ -1,0 +1,55 @@
+package seedu.mark.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.mark.commons.util.CollectionUtil.requireAllNonNull;
+
+import seedu.mark.logic.commands.exceptions.CommandException;
+import seedu.mark.logic.commands.results.CommandResult;
+import seedu.mark.model.Model;
+import seedu.mark.storage.Storage;
+
+/**
+ * Deletes an automatic tagger from Mark.
+ */
+public class AutotagDeleteCommand extends Command {
+
+    public static final String COMMAND_WORD = "autotag-delete";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Deletes the automatic tagger with the given tag name.\n"
+            + "Parameters: TAG_NAME\n"
+            + "Example: " + COMMAND_WORD + " Quiz";
+
+    public static final String MESSAGE_AUTOTAG_DELETED = "Autotag with this tag name deleted successfully: %1$s";
+    public static final String MESSAGE_AUTOTAG_DOES_NOT_EXIST = "No autotag with this tag name was found: %1$s";
+
+    private final String taggerName;
+
+    public AutotagDeleteCommand(String taggerName) {
+        requireNonNull(taggerName);
+        this.taggerName = taggerName;
+    }
+
+    @Override
+    public CommandResult execute(Model model, Storage storage) throws CommandException {
+        requireAllNonNull(model, storage);
+
+        boolean taggerRemoved = model.removeTagger(taggerName);
+
+        if (!taggerRemoved) {
+            throw new CommandException(String.format(MESSAGE_AUTOTAG_DOES_NOT_EXIST, taggerName));
+        }
+
+        String resultMessage = String.format(MESSAGE_AUTOTAG_DELETED, taggerName);
+        model.saveMark(resultMessage);
+        return new CommandResult(resultMessage);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AutotagDeleteCommand // instanceof handles nulls
+                && taggerName.equals(((AutotagDeleteCommand) other).taggerName)); // state check
+    }
+
+}

--- a/src/main/java/seedu/mark/logic/parser/AutotagCommandParser.java
+++ b/src/main/java/seedu/mark/logic/parser/AutotagCommandParser.java
@@ -28,7 +28,7 @@ public class AutotagCommandParser implements Parser<AutotagCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_URL, PREFIX_NOT_NAME, PREFIX_NOT_URL);
 
-        if (argMultimap.getPreamble().isEmpty()) {
+        if (argMultimap.getPreamble().isEmpty() || argMultimap.getPreamble().split(" ").length > 1) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AutotagCommand.MESSAGE_USAGE));
         }
 

--- a/src/main/java/seedu/mark/logic/parser/AutotagCommandParser.java
+++ b/src/main/java/seedu/mark/logic/parser/AutotagCommandParser.java
@@ -7,22 +7,16 @@ import static seedu.mark.logic.parser.CliSyntax.PREFIX_NOT_NAME;
 import static seedu.mark.logic.parser.CliSyntax.PREFIX_NOT_URL;
 import static seedu.mark.logic.parser.CliSyntax.PREFIX_URL;
 
-import java.util.function.Predicate;
-
 import seedu.mark.logic.commands.AutotagCommand;
 import seedu.mark.logic.parser.exceptions.ParseException;
 import seedu.mark.model.autotag.SelectiveBookmarkTagger;
-import seedu.mark.model.bookmark.Bookmark;
-import seedu.mark.model.predicates.NameContainsKeywordsPredicate;
-import seedu.mark.model.predicates.UrlContainsKeywordsPredicate;
+import seedu.mark.model.predicates.BookmarkPredicate;
 import seedu.mark.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new AutotagCommand object
  */
 public class AutotagCommandParser implements Parser<AutotagCommand> {
-
-    public static final Predicate<Bookmark> DEFAULT_PREDICATE = bookmark -> true;
 
     /**
      * Parses the given {@code String} of arguments in the context of the AutotagCommand
@@ -40,29 +34,22 @@ public class AutotagCommandParser implements Parser<AutotagCommand> {
 
         Tag tagToApply = ParserUtil.parseTag(argMultimap.getPreamble());
 
-        boolean hasConditions = false;
-        Predicate<Bookmark> predicate = DEFAULT_PREDICATE;
+        BookmarkPredicate predicate = new BookmarkPredicate();
 
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            hasConditions = true;
-            predicate = predicate.and(new NameContainsKeywordsPredicate(argMultimap.getAllValues(PREFIX_NAME)));
+            predicate = predicate.withNameKeywords(argMultimap.getAllValues(PREFIX_NAME));
         }
         if (argMultimap.getValue(PREFIX_URL).isPresent()) {
-            hasConditions = true;
-            predicate = predicate.and(new UrlContainsKeywordsPredicate(argMultimap.getAllValues(PREFIX_URL)));
+            predicate = predicate.withUrlKeywords(argMultimap.getAllValues(PREFIX_URL));
         }
         if (argMultimap.getValue(PREFIX_NOT_NAME).isPresent()) {
-            hasConditions = true;
-            predicate = predicate.and(
-                    new NameContainsKeywordsPredicate(argMultimap.getAllValues(PREFIX_NOT_NAME)).negate());
+            predicate = predicate.withoutNameKeywords(argMultimap.getAllValues(PREFIX_NOT_NAME));
         }
         if (argMultimap.getValue(PREFIX_NOT_URL).isPresent()) {
-            hasConditions = true;
-            predicate = predicate.and(
-                    new UrlContainsKeywordsPredicate(argMultimap.getAllValues(PREFIX_NOT_URL)).negate());
+            predicate = predicate.withoutUrlKeywords(argMultimap.getAllValues(PREFIX_NOT_URL));
         }
 
-        if (!hasConditions) {
+        if (predicate.isEmpty()) {
             throw new ParseException(AutotagCommand.MESSAGE_NO_CONDITION_SPECIFIED);
         }
 

--- a/src/main/java/seedu/mark/logic/parser/AutotagCommandParser.java
+++ b/src/main/java/seedu/mark/logic/parser/AutotagCommandParser.java
@@ -2,7 +2,9 @@ package seedu.mark.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.mark.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.mark.logic.parser.CliSyntax.PREFIX_FOLDER;
 import static seedu.mark.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.mark.logic.parser.CliSyntax.PREFIX_NOT_FOLDER;
 import static seedu.mark.logic.parser.CliSyntax.PREFIX_NOT_NAME;
 import static seedu.mark.logic.parser.CliSyntax.PREFIX_NOT_URL;
 import static seedu.mark.logic.parser.CliSyntax.PREFIX_URL;
@@ -26,9 +28,10 @@ public class AutotagCommandParser implements Parser<AutotagCommand> {
     public AutotagCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_URL, PREFIX_NOT_NAME, PREFIX_NOT_URL);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_URL, PREFIX_NOT_NAME, PREFIX_NOT_URL,
+                        PREFIX_FOLDER, PREFIX_NOT_FOLDER);
 
-        if (argMultimap.getPreamble().isEmpty() || argMultimap.getPreamble().split(" ").length > 1) {
+        if (argMultimap.getPreamble().isEmpty() || argMultimap.getPreamble().split("\\s+").length > 1) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AutotagCommand.MESSAGE_USAGE));
         }
 
@@ -40,6 +43,7 @@ public class AutotagCommandParser implements Parser<AutotagCommand> {
             predicate = predicate.withNameKeywords(argMultimap.getAllValues(PREFIX_NAME));
         }
         if (argMultimap.getValue(PREFIX_URL).isPresent()) {
+            // TODO: handle empty URL parameter
             predicate = predicate.withUrlKeywords(argMultimap.getAllValues(PREFIX_URL));
         }
         if (argMultimap.getValue(PREFIX_NOT_NAME).isPresent()) {
@@ -47,6 +51,12 @@ public class AutotagCommandParser implements Parser<AutotagCommand> {
         }
         if (argMultimap.getValue(PREFIX_NOT_URL).isPresent()) {
             predicate = predicate.withoutUrlKeywords(argMultimap.getAllValues(PREFIX_NOT_URL));
+        }
+        if (argMultimap.getValue(PREFIX_FOLDER).isPresent()) {
+            predicate = predicate.withFolder(argMultimap.getAllValues(PREFIX_FOLDER));
+        }
+        if (argMultimap.getValue(PREFIX_NOT_FOLDER).isPresent()) {
+            predicate = predicate.withoutFolder(argMultimap.getAllValues(PREFIX_NOT_FOLDER));
         }
 
         if (predicate.isEmpty()) {

--- a/src/main/java/seedu/mark/logic/parser/AutotagCommandParser.java
+++ b/src/main/java/seedu/mark/logic/parser/AutotagCommandParser.java
@@ -9,6 +9,8 @@ import static seedu.mark.logic.parser.CliSyntax.PREFIX_NOT_NAME;
 import static seedu.mark.logic.parser.CliSyntax.PREFIX_NOT_URL;
 import static seedu.mark.logic.parser.CliSyntax.PREFIX_URL;
 
+import java.util.List;
+
 import seedu.mark.logic.commands.AutotagCommand;
 import seedu.mark.logic.parser.exceptions.ParseException;
 import seedu.mark.model.autotag.SelectiveBookmarkTagger;
@@ -40,23 +42,34 @@ public class AutotagCommandParser implements Parser<AutotagCommand> {
         BookmarkPredicate predicate = new BookmarkPredicate();
 
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
-            predicate = predicate.withNameKeywords(argMultimap.getAllValues(PREFIX_NAME));
+            List<String> keywords = argMultimap.getAllValues(PREFIX_NAME);
+            checkValuesNonEmpty(keywords);
+            predicate = predicate.withNameKeywords(keywords);
         }
         if (argMultimap.getValue(PREFIX_URL).isPresent()) {
-            // TODO: handle empty URL parameter
-            predicate = predicate.withUrlKeywords(argMultimap.getAllValues(PREFIX_URL));
-        }
-        if (argMultimap.getValue(PREFIX_NOT_NAME).isPresent()) {
-            predicate = predicate.withoutNameKeywords(argMultimap.getAllValues(PREFIX_NOT_NAME));
-        }
-        if (argMultimap.getValue(PREFIX_NOT_URL).isPresent()) {
-            predicate = predicate.withoutUrlKeywords(argMultimap.getAllValues(PREFIX_NOT_URL));
+            List<String> keywords = argMultimap.getAllValues(PREFIX_URL);
+            checkValuesNonEmpty(keywords);
+            predicate = predicate.withUrlKeywords(keywords);
         }
         if (argMultimap.getValue(PREFIX_FOLDER).isPresent()) {
-            predicate = predicate.withFolder(argMultimap.getAllValues(PREFIX_FOLDER));
+            List<String> folderNames = argMultimap.getAllValues(PREFIX_FOLDER);
+            checkValuesNonEmpty(folderNames);
+            predicate = predicate.withFolder(folderNames);
+        }
+        if (argMultimap.getValue(PREFIX_NOT_NAME).isPresent()) {
+            List<String> keywords = argMultimap.getAllValues(PREFIX_NOT_NAME);
+            checkValuesNonEmpty(keywords);
+            predicate = predicate.withoutNameKeywords(keywords);
+        }
+        if (argMultimap.getValue(PREFIX_NOT_URL).isPresent()) {
+            List<String> keywords = argMultimap.getAllValues(PREFIX_NOT_URL);
+            checkValuesNonEmpty(keywords);
+            predicate = predicate.withoutUrlKeywords(keywords);
         }
         if (argMultimap.getValue(PREFIX_NOT_FOLDER).isPresent()) {
-            predicate = predicate.withoutFolder(argMultimap.getAllValues(PREFIX_NOT_FOLDER));
+            List<String> folderNames = argMultimap.getAllValues(PREFIX_NOT_FOLDER);
+            checkValuesNonEmpty(folderNames);
+            predicate = predicate.withoutFolder(folderNames);
         }
 
         if (predicate.isEmpty()) {
@@ -66,6 +79,18 @@ public class AutotagCommandParser implements Parser<AutotagCommand> {
         SelectiveBookmarkTagger tagger = new SelectiveBookmarkTagger(tagToApply, predicate);
 
         return new AutotagCommand(tagger);
+    }
+
+    /**
+     * Checks that there is no empty value in the given list.
+     *
+     * @param values Strings to check.
+     * @throws ParseException if any String in {@code values} is blank.
+     */
+    private static void checkValuesNonEmpty(List<String> values) throws ParseException {
+        if (values.stream().anyMatch(String::isBlank)) {
+            throw new ParseException(AutotagCommand.MESSAGE_CONDITION_EMPTY);
+        }
     }
 
 }

--- a/src/main/java/seedu/mark/logic/parser/AutotagDeleteCommandParser.java
+++ b/src/main/java/seedu/mark/logic/parser/AutotagDeleteCommandParser.java
@@ -1,0 +1,32 @@
+package seedu.mark.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.mark.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.mark.logic.commands.AutotagDeleteCommand;
+import seedu.mark.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new {@link AutotagDeleteCommand} object
+ */
+public class AutotagDeleteCommandParser implements Parser<AutotagDeleteCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AutotagDeleteCommand
+     * and returns an AutotagDeleteCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public AutotagDeleteCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        String trimmedArgs = args.trim();
+
+        // exactly one tag name should be present
+        if (trimmedArgs.isEmpty() || trimmedArgs.split("\\s+").length != 1) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, AutotagDeleteCommand.MESSAGE_USAGE));
+        }
+
+        return new AutotagDeleteCommand(trimmedArgs);
+    }
+
+}

--- a/src/main/java/seedu/mark/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/mark/logic/parser/CliSyntax.java
@@ -8,6 +8,7 @@ public class CliSyntax {
     /* Prefix definitions */
     public static final Prefix PREFIX_FOLDER = new Prefix("f/");
     public static final Prefix PREFIX_NAME = new Prefix("n/");
+    public static final Prefix PREFIX_NOT_FOLDER = new Prefix("nf/");
     public static final Prefix PREFIX_NOT_NAME = new Prefix("nn/");
     public static final Prefix PREFIX_NOT_URL = new Prefix("nu/");
     public static final Prefix PREFIX_NOTE = new Prefix("n/");

--- a/src/main/java/seedu/mark/logic/parser/MarkParser.java
+++ b/src/main/java/seedu/mark/logic/parser/MarkParser.java
@@ -10,6 +10,7 @@ import seedu.mark.logic.commands.AddCommand;
 import seedu.mark.logic.commands.AddFolderCommand;
 import seedu.mark.logic.commands.AddReminderCommand;
 import seedu.mark.logic.commands.AutotagCommand;
+import seedu.mark.logic.commands.AutotagDeleteCommand;
 import seedu.mark.logic.commands.CacheCommand;
 import seedu.mark.logic.commands.ClearCommand;
 import seedu.mark.logic.commands.Command;
@@ -107,6 +108,9 @@ public class MarkParser {
 
         case AddReminderCommand.COMMAND_WORD:
             return new AddReminderCommandParser().parse(arguments);
+
+        case AutotagDeleteCommand.COMMAND_WORD:
+            return new AutotagDeleteCommandParser().parse(arguments);
 
         case AutotagCommand.COMMAND_WORD:
             return new AutotagCommandParser().parse(arguments);

--- a/src/main/java/seedu/mark/model/Mark.java
+++ b/src/main/java/seedu/mark/model/Mark.java
@@ -182,7 +182,7 @@ public class Mark implements ReadOnlyMark {
      * Replaces the taggers in the current {@code AutotagController} with
      * taggers from {@code autotagController}.
      */
-    private void setAutotagController(AutotagController autotagController) {
+    public void setAutotagController(AutotagController autotagController) {
         requireNonNull(autotagController);
 
         this.autotagController.removeAllTaggers();

--- a/src/main/java/seedu/mark/model/Mark.java
+++ b/src/main/java/seedu/mark/model/Mark.java
@@ -182,21 +182,42 @@ public class Mark implements ReadOnlyMark {
      * Replaces the taggers in the current {@code AutotagController} with
      * taggers from {@code autotagController}.
      */
-    public void setAutotagController(AutotagController autotagController) {
+    private void setAutotagController(AutotagController autotagController) {
         requireNonNull(autotagController);
 
         this.autotagController.removeAllTaggers();
         autotagController.getTaggers().forEach(this.autotagController::addTagger);
     }
 
+    /**
+     * Checks whether Mark contains the given tagger.
+     */
     public boolean hasTagger(SelectiveBookmarkTagger tagger) {
         return autotagController.hasTagger(tagger);
     }
 
+    /**
+     * Adds a {@link SelectiveBookmarkTagger} to Mark.
+     *
+     * @param tagger {@link SelectiveBookmarkTagger} to be added.
+     */
     public void addTagger(SelectiveBookmarkTagger tagger) {
         autotagController.addTagger(tagger);
     }
 
+    /**
+     * Removes the given tagger from Mark.
+     *
+     * @param taggerName name of the tagger to be removed.
+     * @return false if the tagger is not found.
+     */
+    public boolean removeTagger(String taggerName) {
+        return autotagController.removeTagger(taggerName);
+    }
+
+    /**
+     * Applies all {@link SelectiveBookmarkTagger}s to the bookmarks in Mark.
+     */
     public void applyAllTaggers() {
         setBookmarks(autotagController.applyTaggersToList(getBookmarkList()));
     }

--- a/src/main/java/seedu/mark/model/Model.java
+++ b/src/main/java/seedu/mark/model/Model.java
@@ -127,6 +127,14 @@ public interface Model {
     void addTagger(SelectiveBookmarkTagger tagger);
 
     /**
+     * Removes the tagger with the given {@code taggerName} from Mark.
+     *
+     * @param taggerName name of the tagger to be removed.
+     * @return false if the tagger is not found.
+     */
+    boolean removeTagger(String taggerName);
+
+    /**
      * Activates all taggers in Mark to apply tags to Mark's bookmarks based
      * on their respective conditions.
      */

--- a/src/main/java/seedu/mark/model/ModelManager.java
+++ b/src/main/java/seedu/mark/model/ModelManager.java
@@ -182,15 +182,19 @@ public class ModelManager implements Model {
     @Override
     public boolean hasTagger(SelectiveBookmarkTagger tagger) {
         requireNonNull(tagger);
-
         return versionedMark.hasTagger(tagger);
     }
 
     @Override
     public void addTagger(SelectiveBookmarkTagger tagger) {
         requireNonNull(tagger);
-
         versionedMark.addTagger(tagger);
+    }
+
+    @Override
+    public boolean removeTagger(String taggerName) {
+        requireNonNull(taggerName);
+        return versionedMark.removeTagger(taggerName);
     }
 
     @Override

--- a/src/main/java/seedu/mark/model/autotag/AutotagController.java
+++ b/src/main/java/seedu/mark/model/autotag/AutotagController.java
@@ -4,12 +4,13 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import seedu.mark.model.bookmark.Bookmark;
 
 /**
- * Manages {@code SelectiveBookmarkTagger}s in Mark.
+ * Manages {@link SelectiveBookmarkTagger}s in Mark.
  */
 public class AutotagController {
     private final List<SelectiveBookmarkTagger> taggers;
@@ -24,14 +25,14 @@ public class AutotagController {
     /**
      * Creates a new {@code AutotagController} with the given list of taggers.
      *
-     * @param taggers List of {@code SelectiveBookmarkTagger}s to manage.
+     * @param taggers List of {@link SelectiveBookmarkTagger}s to manage.
      */
     public AutotagController(List<SelectiveBookmarkTagger> taggers) {
         this.taggers = taggers;
     }
 
     /**
-     * Returns a shallow copy of the {@code SelectiveBookmarkTagger} list
+     * Returns a shallow copy of the {@link SelectiveBookmarkTagger} list
      * used by this {@code AutotagController}.
      */
     public List<SelectiveBookmarkTagger> getTaggers() {
@@ -39,7 +40,7 @@ public class AutotagController {
     }
 
     /**
-     * Checks whether the given {@code SelectiveBookmarkTagger} exists in this
+     * Checks whether the given {@link SelectiveBookmarkTagger} exists in this
      * {@code AutotagController}.
      *
      * @param tagger SelectiveBookmarkTagger to be checked.
@@ -52,7 +53,7 @@ public class AutotagController {
     }
 
     /**
-     * Adds a {@code SelectiveBookmarkTagger} to the existing list of taggers
+     * Adds a {@link SelectiveBookmarkTagger} to the existing list of taggers
      * to apply.
      *
      * @param tagger A new SelectiveBookmarkTagger to add.
@@ -63,6 +64,32 @@ public class AutotagController {
     }
 
     /**
+     * Removes the given {@code tagger} from this {@code AutotagController}.
+     *
+     * @param tagger {@link SelectiveBookmarkTagger} to be removed.
+     * @return {@code false} if the tagger is not found.
+     */
+    private boolean removeTagger(SelectiveBookmarkTagger tagger) {
+        return taggers.remove(tagger);
+    }
+
+    /**
+     * Removes the {@link SelectiveBookmarkTagger} with the given
+     * {@code taggerName} from this {@code AutotagController}.
+     *
+     * @param taggerName Name of the tag of the {@link SelectiveBookmarkTagger}
+     *                   to be removed.
+     * @return {@code false} if the tagger is not found.
+     */
+    public boolean removeTagger(String taggerName) {
+        Optional<SelectiveBookmarkTagger> taggerToRemove =
+                taggers.stream().filter(tagger -> taggerName.equals(tagger.getTagToApply().tagName))
+                        .findFirst();
+        // TODO: find a way to use #hasTagger() instead of relying on side effects
+        return taggerToRemove.isPresent() ? removeTagger(taggerToRemove.get()) : false;
+    }
+
+    /**
      * Removes all taggers from this {@code AutotagController}.
      */
     public void removeAllTaggers() {
@@ -70,9 +97,9 @@ public class AutotagController {
     }
 
     /**
-     * Creates a {@code Bookmark} that results from selectively applying all
+     * Creates a {@link Bookmark} that results from selectively applying all
      * of the current controller's {@code taggers} to the given
-     * {@code Bookmark}.
+     * {@link Bookmark}.
      *
      * @param bookmark Bookmark to be tagged
      * @return A tagged Bookmark
@@ -88,7 +115,7 @@ public class AutotagController {
     }
 
     /**
-     * Applies each of the {@code SelectiveBookmarkTagger}s in {@code taggers}
+     * Applies each of the {@link SelectiveBookmarkTagger}s in {@code taggers}
      * to all of the bookmarks in the given list.
      *
      * @param bookmarks List of Bookmarks that each tagger should be applied to.

--- a/src/main/java/seedu/mark/model/autotag/SelectiveBookmarkTagger.java
+++ b/src/main/java/seedu/mark/model/autotag/SelectiveBookmarkTagger.java
@@ -38,7 +38,7 @@ public class SelectiveBookmarkTagger extends BookmarkTagger {
 
     @Override
     public String toString() {
-        return "Tagger: Applies the tag " + getTagToApply().toString() + " to bookmarks";
-        // TODO: Make a better toString()
+        return "Tagger: Applies the tag " + getTagToApply().toString() + " to bookmarks "
+                + "that match the predicate " + predicate.toString();
     }
 }

--- a/src/main/java/seedu/mark/model/autotag/SelectiveBookmarkTagger.java
+++ b/src/main/java/seedu/mark/model/autotag/SelectiveBookmarkTagger.java
@@ -1,20 +1,27 @@
 package seedu.mark.model.autotag;
 
-import java.util.function.Predicate;
-
 import seedu.mark.model.bookmark.Bookmark;
+import seedu.mark.model.predicates.BookmarkPredicate;
 import seedu.mark.model.tag.Tag;
 
 /**
  * A type of BookmarkTagger that tags specific Bookmarks only, based on
- * whether they match a given {@code Predicate}.
+ * whether they match a given {@code BookmarkPredicate}.
  */
 public class SelectiveBookmarkTagger extends BookmarkTagger {
-    private final Predicate<Bookmark> predicate;
 
-    public SelectiveBookmarkTagger(Tag tag, Predicate<Bookmark> predicate) {
+    private final BookmarkPredicate predicate;
+
+    public SelectiveBookmarkTagger(Tag tag, BookmarkPredicate predicate) {
         super(tag);
         this.predicate = predicate;
+    }
+
+    /**
+     * Returns the {@code BookmarkPredicate} used in this {@code SelectiveBookmarkTagger}.
+     */
+    public BookmarkPredicate getPredicate() {
+        return predicate;
     }
 
     /**

--- a/src/main/java/seedu/mark/model/bookmark/Url.java
+++ b/src/main/java/seedu/mark/model/bookmark/Url.java
@@ -9,7 +9,7 @@ import static seedu.mark.commons.util.AppUtil.checkArgument;
  */
 public class Url {
 
-    private static final String SPECIAL_CHARACTERS = "\\(\\.\\-_~!\\$&'\\*\\+,;=:@\\)";
+    private static final String SPECIAL_CHARACTERS = "\\(\\.\\-_~!\\$&'\\*\\+,;=:@\\)"; // (.-_~!$&'*+,;=:@)
     private static final String NON_PERIOD_SPECIAL_CHARACTERS = "\\(\\-_~!\\$&'\\*\\+,;=:@\\)";
     public static final String MESSAGE_CONSTRAINTS = "URLs should be of the format "
             + "scheme://authority[/path][?query][#fragment][/] "
@@ -25,17 +25,23 @@ public class Url {
             + "4. Next, a URL may contain a query string, which begins with a '?'.\n"
             + "5. It may also contain a fragment after the query string (if present), which begins with a '#'.\n"
             + "6. Finally, a URL can end with an optional slash '/'.\n";
-    private static final String REGEX_URL_SCHEME = "^((http(s?))|(ftp)|(file))://";
+
+    // TODO: Make %HH a valid URL character, where HH are two hexadecimal digits
     // alphanumeric and special characters
     private static final String URL_CHARACTERS = "[\\w" + SPECIAL_CHARACTERS + "]";
     // alphanumeric and special characters excluding period '.'
     private static final String NON_PERIOD_URL_CHARACTERS = "[\\w" + NON_PERIOD_SPECIAL_CHARACTERS + "]";
+    // URL characters and '/' and '?'
+    private static final String QUERY_AND_FRAGMENT_CHARACTERS = "[\\w" + SPECIAL_CHARACTERS + "/?]";
+
+    private static final String REGEX_URL_SCHEME = "^((http(s?))|(ftp)|(file))://";
     private static final String REGEX_URL_AUTHORITY =
             NON_PERIOD_URL_CHARACTERS + URL_CHARACTERS + "*" + NON_PERIOD_URL_CHARACTERS;
     private static final String REGEX_URL_PATH_SEGMENT = "/" + URL_CHARACTERS + "+";
     private static final String REGEX_URL_PATH = "(" + REGEX_URL_PATH_SEGMENT + ")*"; // zero or more path segments
-    private static final String REGEX_URL_QUERY = "(\\?" + URL_CHARACTERS + "+)?"; // optional query
-    private static final String REGEX_URL_FRAGMENT = "(#" + URL_CHARACTERS + "+)?"; // optional fragment
+    private static final String REGEX_URL_QUERY = "(\\?" + QUERY_AND_FRAGMENT_CHARACTERS + "+)?"; // optional query
+    private static final String REGEX_URL_FRAGMENT = "(#" + QUERY_AND_FRAGMENT_CHARACTERS + "+)?"; // optional fragment
+
     public static final String VALIDATION_REGEX = REGEX_URL_SCHEME + REGEX_URL_AUTHORITY
             + REGEX_URL_PATH + REGEX_URL_QUERY + REGEX_URL_FRAGMENT + "/?$";
 

--- a/src/main/java/seedu/mark/model/bookmark/Url.java
+++ b/src/main/java/seedu/mark/model/bookmark/Url.java
@@ -26,13 +26,16 @@ public class Url {
             + "5. It may also contain a fragment after the query string (if present), which begins with a '#'.\n"
             + "6. Finally, a URL can end with an optional slash '/'.\n";
 
-    // TODO: Make %HH a valid URL character, where HH are two hexadecimal digits
-    // alphanumeric and special characters
-    private static final String URL_CHARACTERS = "[\\w" + SPECIAL_CHARACTERS + "]";
+    // encoded ASCII character %FF, where FF are two hexadecimal digits
+    private static final String ENCODED_ASCII_CHARACTER = "(%[0-9a-fA-F]{2})";
+    // alphanumeric, special, or encoded characters
+    private static final String URL_CHARACTERS = "([\\w" + SPECIAL_CHARACTERS + "]|" + ENCODED_ASCII_CHARACTER + ")";
     // alphanumeric and special characters excluding period '.'
-    private static final String NON_PERIOD_URL_CHARACTERS = "[\\w" + NON_PERIOD_SPECIAL_CHARACTERS + "]";
+    private static final String NON_PERIOD_URL_CHARACTERS = "([\\w" + NON_PERIOD_SPECIAL_CHARACTERS + "]|"
+            + ENCODED_ASCII_CHARACTER + ")";
     // URL characters and '/' and '?'
-    private static final String QUERY_AND_FRAGMENT_CHARACTERS = "[\\w" + SPECIAL_CHARACTERS + "/?]";
+    private static final String QUERY_AND_FRAGMENT_CHARACTERS = "([\\w" + SPECIAL_CHARACTERS + "/?]|"
+            + ENCODED_ASCII_CHARACTER + ")";
 
     private static final String REGEX_URL_SCHEME = "^((http(s?))|(ftp)|(file))://";
     private static final String REGEX_URL_AUTHORITY =

--- a/src/main/java/seedu/mark/model/predicates/BookmarkPredicate.java
+++ b/src/main/java/seedu/mark/model/predicates/BookmarkPredicate.java
@@ -84,7 +84,7 @@ public class BookmarkPredicate implements Predicate<Bookmark> {
         requireNonNull(nameKeywords);
         isEmpty = false;
 
-        Set<String> newNameKeywords = new HashSet<>(nameKeywords);
+        Set<String> newNameKeywords = new HashSet<>(this.nameKeywords);
         newNameKeywords.addAll(nameKeywords);
         return new BookmarkPredicate(newNameKeywords,
                 this.notNameKeywords, this.urlKeywords,
@@ -104,7 +104,7 @@ public class BookmarkPredicate implements Predicate<Bookmark> {
         requireNonNull(notNameKeywords);
         isEmpty = false;
 
-        Set<String> newNotNameKeywords = new HashSet<>(notNameKeywords);
+        Set<String> newNotNameKeywords = new HashSet<>(this.notNameKeywords);
         newNotNameKeywords.addAll(notNameKeywords);
         return new BookmarkPredicate(this.nameKeywords,
                 newNotNameKeywords, this.urlKeywords,
@@ -123,7 +123,7 @@ public class BookmarkPredicate implements Predicate<Bookmark> {
         requireNonNull(urlKeywords);
         isEmpty = false;
 
-        Set<String> newUrlKeywords = new HashSet<>(urlKeywords);
+        Set<String> newUrlKeywords = new HashSet<>(this.urlKeywords);
         newUrlKeywords.addAll(urlKeywords);
         return new BookmarkPredicate(this.nameKeywords,
                 this.notNameKeywords, newUrlKeywords,
@@ -143,7 +143,7 @@ public class BookmarkPredicate implements Predicate<Bookmark> {
         requireNonNull(notUrlKeywords);
         isEmpty = false;
 
-        Set<String> newNotUrlKeywords = new HashSet<>(notUrlKeywords);
+        Set<String> newNotUrlKeywords = new HashSet<>(this.notUrlKeywords);
         newNotUrlKeywords.addAll(notUrlKeywords);
         return new BookmarkPredicate(this.nameKeywords,
                 this.notNameKeywords, this.urlKeywords,
@@ -154,7 +154,10 @@ public class BookmarkPredicate implements Predicate<Bookmark> {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof BookmarkPredicate // instanceof handles nulls
-                && nameKeywords.equals(((BookmarkPredicate) other).nameKeywords)); // state check
+                && nameKeywords.equals(((BookmarkPredicate) other).nameKeywords)
+                && notNameKeywords.equals(((BookmarkPredicate) other).notNameKeywords)
+                && urlKeywords.equals(((BookmarkPredicate) other).urlKeywords)
+                && notUrlKeywords.equals((((BookmarkPredicate) other).notUrlKeywords))); // state check
     }
 
 }

--- a/src/main/java/seedu/mark/model/predicates/BookmarkPredicate.java
+++ b/src/main/java/seedu/mark/model/predicates/BookmarkPredicate.java
@@ -32,12 +32,28 @@ public class BookmarkPredicate implements Predicate<Bookmark> {
     }
 
     private BookmarkPredicate(List<String> nameKeywords, List<String> notNameKeywords,
-                             List<String> urlKeywords, List<String> notUrlKeywords, Predicate<Bookmark> predicate) {
+                              List<String> urlKeywords, List<String> notUrlKeywords, Predicate<Bookmark> predicate) {
         this.nameKeywords = nameKeywords;
         this.notNameKeywords = notNameKeywords;
         this.urlKeywords = urlKeywords;
         this.notUrlKeywords = notUrlKeywords;
         this.predicate = predicate;
+    }
+
+    public List<String> getNameKeywords() {
+        return nameKeywords;
+    }
+
+    public List<String> getNotNameKeywords() {
+        return notNameKeywords;
+    }
+
+    public List<String> getUrlKeywords() {
+        return urlKeywords;
+    }
+
+    public List<String> getNotUrlKeywords() {
+        return notUrlKeywords;
     }
 
     @Override

--- a/src/main/java/seedu/mark/model/predicates/BookmarkPredicate.java
+++ b/src/main/java/seedu/mark/model/predicates/BookmarkPredicate.java
@@ -14,10 +14,14 @@ import seedu.mark.model.bookmark.Bookmark;
  * in the current predicate.
  */
 public class BookmarkPredicate implements Predicate<Bookmark> {
+    // TODO: Find a way to reduce code duplication
+
     private final Set<String> nameKeywords;
     private final Set<String> notNameKeywords;
     private final Set<String> urlKeywords;
     private final Set<String> notUrlKeywords;
+    private final Set<String> folderNames;
+    private final Set<String> notFolderNames;
 
     private final Predicate<Bookmark> predicate;
 
@@ -28,16 +32,21 @@ public class BookmarkPredicate implements Predicate<Bookmark> {
      * {@code predicate#test(Bookmark)} is called.
      */
     public BookmarkPredicate() {
-        this(new HashSet<>(), new HashSet<>(), new HashSet<>(), new HashSet<>(), bookmark -> true);
+        this(new HashSet<>(), new HashSet<>(), new HashSet<>(), new HashSet<>(),
+                new HashSet<>(), new HashSet<>(), bookmark -> true);
         this.isEmpty = true;
     }
 
     private BookmarkPredicate(Set<String> nameKeywords, Set<String> notNameKeywords,
-                              Set<String> urlKeywords, Set<String> notUrlKeywords, Predicate<Bookmark> predicate) {
+                              Set<String> urlKeywords, Set<String> notUrlKeywords,
+                              Set<String> folderNames, Set<String> notFolderNames,
+                              Predicate<Bookmark> predicate) {
         this.nameKeywords = new HashSet<>(nameKeywords);
         this.notNameKeywords = new HashSet<>(notNameKeywords);
         this.urlKeywords = new HashSet<>(urlKeywords);
         this.notUrlKeywords = new HashSet<>(notUrlKeywords);
+        this.folderNames = folderNames;
+        this.notFolderNames = notFolderNames;
         this.predicate = predicate;
     }
 
@@ -87,8 +96,9 @@ public class BookmarkPredicate implements Predicate<Bookmark> {
         Set<String> newNameKeywords = new HashSet<>(this.nameKeywords);
         newNameKeywords.addAll(nameKeywords);
         return new BookmarkPredicate(newNameKeywords,
-                this.notNameKeywords, this.urlKeywords,
-                this.notUrlKeywords, predicate.and(new NameContainsKeywordsPredicate(nameKeywords)));
+                this.notNameKeywords, this.urlKeywords, this.notUrlKeywords,
+                this.folderNames, this.notFolderNames,
+                predicate.and(new NameContainsKeywordsPredicate(nameKeywords)));
     }
 
     /**
@@ -107,8 +117,9 @@ public class BookmarkPredicate implements Predicate<Bookmark> {
         Set<String> newNotNameKeywords = new HashSet<>(this.notNameKeywords);
         newNotNameKeywords.addAll(notNameKeywords);
         return new BookmarkPredicate(this.nameKeywords,
-                newNotNameKeywords, this.urlKeywords,
-                this.notUrlKeywords, predicate.and(new NameContainsKeywordsPredicate(notNameKeywords).negate()));
+                newNotNameKeywords, this.urlKeywords, this.notUrlKeywords,
+                this.folderNames, this.notFolderNames,
+                predicate.and(new NameContainsKeywordsPredicate(notNameKeywords).negate()));
     }
 
     /**
@@ -126,8 +137,8 @@ public class BookmarkPredicate implements Predicate<Bookmark> {
         Set<String> newUrlKeywords = new HashSet<>(this.urlKeywords);
         newUrlKeywords.addAll(urlKeywords);
         return new BookmarkPredicate(this.nameKeywords,
-                this.notNameKeywords, newUrlKeywords,
-                this.notUrlKeywords, predicate.and(new UrlContainsKeywordsPredicate(urlKeywords)));
+                this.notNameKeywords, newUrlKeywords, this.notUrlKeywords,
+                this.folderNames, this.notFolderNames, predicate.and(new UrlContainsKeywordsPredicate(urlKeywords)));
     }
 
     /**
@@ -146,8 +157,49 @@ public class BookmarkPredicate implements Predicate<Bookmark> {
         Set<String> newNotUrlKeywords = new HashSet<>(this.notUrlKeywords);
         newNotUrlKeywords.addAll(notUrlKeywords);
         return new BookmarkPredicate(this.nameKeywords,
-                this.notNameKeywords, this.urlKeywords,
-                newNotUrlKeywords, predicate.and(new UrlContainsKeywordsPredicate(notUrlKeywords).negate()));
+                this.notNameKeywords, this.urlKeywords, newNotUrlKeywords,
+                this.folderNames, this.notFolderNames,
+                predicate.and(new UrlContainsKeywordsPredicate(notUrlKeywords).negate()));
+    }
+
+    /**
+     * Creates a new {@code BookmarkPredicate} that checks that a bookmark matches
+     * the current predicate and is in one of the folders in {@code folderNames}.
+     *
+     * @param folderNames names of folders that a bookmark can be in.
+     * @return a new {@code BookmarkPredicate} that contains all of the current
+     *         information and includes the new Folder names.
+     */
+    public BookmarkPredicate withFolder(List<String> folderNames) {
+        requireNonNull(folderNames);
+        isEmpty = false;
+
+        Set<String> newFolderNames = new HashSet<>(this.folderNames);
+        newFolderNames.addAll(folderNames);
+        return new BookmarkPredicate(this.nameKeywords,
+                this.notNameKeywords, this.urlKeywords, this.notUrlKeywords,
+                newFolderNames, this.notFolderNames,
+                predicate.and(new FolderContainsKeywordsPredicate(folderNames)));
+    }
+
+    /**
+     * Creates a new {@code BookmarkPredicate} that checks that a bookmark matches
+     * the current predicate and is not in any of the folders in {@code notFolderNames}.
+     *
+     * @param notFolderNames names of folders that a bookmark should not be in.
+     * @return a new {@code BookmarkPredicate} that contains all of the current
+     *         information and includes the new notFolderNames.
+     */
+    public BookmarkPredicate withoutFolder(List<String> notFolderNames) {
+        requireNonNull(notFolderNames);
+        isEmpty = false;
+
+        Set<String> newNotFolderNames = new HashSet<>(this.folderNames);
+        newNotFolderNames.addAll(notFolderNames);
+        return new BookmarkPredicate(this.nameKeywords,
+                this.notNameKeywords, this.urlKeywords, this.notUrlKeywords,
+                this.folderNames, newNotFolderNames,
+                predicate.and(new FolderContainsKeywordsPredicate(notFolderNames).negate()));
     }
 
     @Override

--- a/src/main/java/seedu/mark/model/predicates/BookmarkPredicate.java
+++ b/src/main/java/seedu/mark/model/predicates/BookmarkPredicate.java
@@ -1,0 +1,143 @@
+package seedu.mark.model.predicates;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.mark.model.bookmark.Bookmark;
+
+/**
+ * A wrapper for {@code Predicate<Bookmark>} that also stores the keywords used
+ * in the current predicate.
+ */
+public class BookmarkPredicate implements Predicate<Bookmark> {
+    private final List<String> nameKeywords;
+    private final List<String> notNameKeywords;
+    private final List<String> urlKeywords;
+    private final List<String> notUrlKeywords;
+
+    private final Predicate<Bookmark> predicate;
+
+    private boolean isEmpty;
+
+    /**
+     * Constructs a new, empty {@code BookmarkPredicate} that returns true whenever
+     * {@code predicate#test(Bookmark)} is called.
+     */
+    public BookmarkPredicate() {
+        this(new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), bookmark -> true);
+        this.isEmpty = true;
+    }
+
+    private BookmarkPredicate(List<String> nameKeywords, List<String> notNameKeywords,
+                             List<String> urlKeywords, List<String> notUrlKeywords, Predicate<Bookmark> predicate) {
+        this.nameKeywords = nameKeywords;
+        this.notNameKeywords = notNameKeywords;
+        this.urlKeywords = urlKeywords;
+        this.notUrlKeywords = notUrlKeywords;
+        this.predicate = predicate;
+    }
+
+    @Override
+    public boolean test(Bookmark bookmark) {
+        return predicate.test(bookmark);
+    }
+
+    /**
+     * Checks whether this {@code BookmarkPredicate} is empty (i.e. has no keywords).
+     * An empty predicate returns true whenever {@code predicate#test(Bookmark)} is called.
+     *
+     * @return true if the predicate is empty and false otherwise.
+     */
+    public boolean isEmpty() {
+        return this.isEmpty;
+    }
+
+    /**
+     * Creates a new {@code BookmarkPredicate} that checks that a bookmark matches
+     * the current predicate and matches any of the keywords in {@code nameKeywords}.
+     *
+     * @param nameKeywords keywords that a bookmark's name should contain.
+     * @return a new {@code BookmarkPredicate} that contains all of the current
+     *         information and includes the new name keywords.
+     */
+    public BookmarkPredicate withNameKeywords(List<String> nameKeywords) {
+        requireNonNull(nameKeywords);
+        isEmpty = false;
+
+        List<String> newNameKeywords = new ArrayList<>(nameKeywords);
+        newNameKeywords.addAll(nameKeywords);
+        return new BookmarkPredicate(newNameKeywords,
+                this.notNameKeywords, this.urlKeywords,
+                this.notUrlKeywords, predicate.and(new NameContainsKeywordsPredicate(nameKeywords)));
+    }
+
+    /**
+     * Creates a new {@code BookmarkPredicate} that checks that a bookmark matches
+     * the current predicate and does not match any of the keywords in
+     * {@code notNameKeywords}.
+     *
+     * @param notNameKeywords keywords that a bookmark's name should not contain.
+     * @return a new {@code BookmarkPredicate} that contains all of the current
+     *         information and includes the new not-name keywords.
+     */
+    public BookmarkPredicate withoutNameKeywords(List<String> notNameKeywords) {
+        requireNonNull(notNameKeywords);
+        isEmpty = false;
+
+        List<String> newNotNameKeywords = new ArrayList<>(notNameKeywords);
+        newNotNameKeywords.addAll(notNameKeywords);
+        return new BookmarkPredicate(this.nameKeywords,
+                newNotNameKeywords, this.urlKeywords,
+                this.notUrlKeywords, predicate.and(new NameContainsKeywordsPredicate(notNameKeywords).negate()));
+    }
+
+    /**
+     * Creates a new {@code BookmarkPredicate} that checks that a bookmark matches
+     * the current predicate and matches any of the keywords in {@code urlKeywords}.
+     *
+     * @param urlKeywords keywords that a bookmark's name should contain.
+     * @return a new {@code BookmarkPredicate} that contains all of the current
+     *         information and includes the new URL keywords.
+     */
+    public BookmarkPredicate withUrlKeywords(List<String> urlKeywords) {
+        requireNonNull(urlKeywords);
+        isEmpty = false;
+
+        List<String> newUrlKeywords = new ArrayList<>(urlKeywords);
+        newUrlKeywords.addAll(urlKeywords);
+        return new BookmarkPredicate(this.nameKeywords,
+                this.notNameKeywords, newUrlKeywords,
+                this.notUrlKeywords, predicate.and(new UrlContainsKeywordsPredicate(urlKeywords)));
+    }
+
+    /**
+     * Creates a new {@code BookmarkPredicate} that checks that a bookmark matches
+     * the current predicate and does not match any of the keywords in
+     * {@code notUrlKeywords}.
+     *
+     * @param notUrlKeywords keywords that a bookmark's URL should not contain.
+     * @return a new {@code BookmarkPredicate} that contains all of the current
+     *         information and includes the new not-URL keywords.
+     */
+    public BookmarkPredicate withoutUrlKeywords(List<String> notUrlKeywords) {
+        requireNonNull(notUrlKeywords);
+        isEmpty = false;
+
+        List<String> newNotUrlKeywords = new ArrayList<>(notUrlKeywords);
+        newNotUrlKeywords.addAll(notUrlKeywords);
+        return new BookmarkPredicate(this.nameKeywords,
+                this.notNameKeywords, this.urlKeywords,
+                newNotUrlKeywords, predicate.and(new UrlContainsKeywordsPredicate(notUrlKeywords).negate()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof BookmarkPredicate // instanceof handles nulls
+                && nameKeywords.equals(((BookmarkPredicate) other).nameKeywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/mark/model/predicates/BookmarkPredicate.java
+++ b/src/main/java/seedu/mark/model/predicates/BookmarkPredicate.java
@@ -2,8 +2,9 @@ package seedu.mark.model.predicates;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import seedu.mark.model.bookmark.Bookmark;
@@ -13,10 +14,10 @@ import seedu.mark.model.bookmark.Bookmark;
  * in the current predicate.
  */
 public class BookmarkPredicate implements Predicate<Bookmark> {
-    private final List<String> nameKeywords;
-    private final List<String> notNameKeywords;
-    private final List<String> urlKeywords;
-    private final List<String> notUrlKeywords;
+    private final Set<String> nameKeywords;
+    private final Set<String> notNameKeywords;
+    private final Set<String> urlKeywords;
+    private final Set<String> notUrlKeywords;
 
     private final Predicate<Bookmark> predicate;
 
@@ -27,32 +28,32 @@ public class BookmarkPredicate implements Predicate<Bookmark> {
      * {@code predicate#test(Bookmark)} is called.
      */
     public BookmarkPredicate() {
-        this(new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), bookmark -> true);
+        this(new HashSet<>(), new HashSet<>(), new HashSet<>(), new HashSet<>(), bookmark -> true);
         this.isEmpty = true;
     }
 
-    private BookmarkPredicate(List<String> nameKeywords, List<String> notNameKeywords,
-                              List<String> urlKeywords, List<String> notUrlKeywords, Predicate<Bookmark> predicate) {
-        this.nameKeywords = nameKeywords;
-        this.notNameKeywords = notNameKeywords;
-        this.urlKeywords = urlKeywords;
-        this.notUrlKeywords = notUrlKeywords;
+    private BookmarkPredicate(Set<String> nameKeywords, Set<String> notNameKeywords,
+                              Set<String> urlKeywords, Set<String> notUrlKeywords, Predicate<Bookmark> predicate) {
+        this.nameKeywords = new HashSet<>(nameKeywords);
+        this.notNameKeywords = new HashSet<>(notNameKeywords);
+        this.urlKeywords = new HashSet<>(urlKeywords);
+        this.notUrlKeywords = new HashSet<>(notUrlKeywords);
         this.predicate = predicate;
     }
 
-    public List<String> getNameKeywords() {
+    public Set<String> getNameKeywords() {
         return nameKeywords;
     }
 
-    public List<String> getNotNameKeywords() {
+    public Set<String> getNotNameKeywords() {
         return notNameKeywords;
     }
 
-    public List<String> getUrlKeywords() {
+    public Set<String> getUrlKeywords() {
         return urlKeywords;
     }
 
-    public List<String> getNotUrlKeywords() {
+    public Set<String> getNotUrlKeywords() {
         return notUrlKeywords;
     }
 
@@ -83,7 +84,7 @@ public class BookmarkPredicate implements Predicate<Bookmark> {
         requireNonNull(nameKeywords);
         isEmpty = false;
 
-        List<String> newNameKeywords = new ArrayList<>(nameKeywords);
+        Set<String> newNameKeywords = new HashSet<>(nameKeywords);
         newNameKeywords.addAll(nameKeywords);
         return new BookmarkPredicate(newNameKeywords,
                 this.notNameKeywords, this.urlKeywords,
@@ -103,7 +104,7 @@ public class BookmarkPredicate implements Predicate<Bookmark> {
         requireNonNull(notNameKeywords);
         isEmpty = false;
 
-        List<String> newNotNameKeywords = new ArrayList<>(notNameKeywords);
+        Set<String> newNotNameKeywords = new HashSet<>(notNameKeywords);
         newNotNameKeywords.addAll(notNameKeywords);
         return new BookmarkPredicate(this.nameKeywords,
                 newNotNameKeywords, this.urlKeywords,
@@ -122,7 +123,7 @@ public class BookmarkPredicate implements Predicate<Bookmark> {
         requireNonNull(urlKeywords);
         isEmpty = false;
 
-        List<String> newUrlKeywords = new ArrayList<>(urlKeywords);
+        Set<String> newUrlKeywords = new HashSet<>(urlKeywords);
         newUrlKeywords.addAll(urlKeywords);
         return new BookmarkPredicate(this.nameKeywords,
                 this.notNameKeywords, newUrlKeywords,
@@ -142,7 +143,7 @@ public class BookmarkPredicate implements Predicate<Bookmark> {
         requireNonNull(notUrlKeywords);
         isEmpty = false;
 
-        List<String> newNotUrlKeywords = new ArrayList<>(notUrlKeywords);
+        Set<String> newNotUrlKeywords = new HashSet<>(notUrlKeywords);
         newNotUrlKeywords.addAll(notUrlKeywords);
         return new BookmarkPredicate(this.nameKeywords,
                 this.notNameKeywords, this.urlKeywords,

--- a/src/main/java/seedu/mark/model/predicates/BookmarkPredicate.java
+++ b/src/main/java/seedu/mark/model/predicates/BookmarkPredicate.java
@@ -160,4 +160,10 @@ public class BookmarkPredicate implements Predicate<Bookmark> {
                 && notUrlKeywords.equals((((BookmarkPredicate) other).notUrlKeywords))); // state check
     }
 
+    @Override
+    public String toString() {
+        return "[name: " + nameKeywords + ", not name: " + notNameKeywords + ", url: "
+                + urlKeywords + ", not url: " + notUrlKeywords + "]";
+        // TODO: Improve toString()
+    }
 }

--- a/src/main/java/seedu/mark/storage/JsonAdaptedAutotagController.java
+++ b/src/main/java/seedu/mark/storage/JsonAdaptedAutotagController.java
@@ -1,0 +1,55 @@
+package seedu.mark.storage;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.mark.model.autotag.AutotagController;
+
+/**
+ * Jackson-friendly version of {@link AutotagController}.
+ */
+public class JsonAdaptedAutotagController {
+
+    private List<JsonAdaptedSelectiveBookmarkTagger> taggers = new ArrayList<>();
+
+    /**
+     * Constructs a {@code JsonAdaptedAutotagController} with the given taggers.
+     *
+     * @param taggers List of {@code SelectiveBookmarkTagger}s.
+     */
+    @JsonCreator
+    public JsonAdaptedAutotagController(@JsonProperty("taggers") List<JsonAdaptedSelectiveBookmarkTagger> taggers) {
+        if (taggers != null) {
+            this.taggers.addAll(taggers);
+        }
+    }
+
+    /**
+     * Instantiates a new Json adapted autotag controller.
+     *
+     * @param source the source
+     */
+    public JsonAdaptedAutotagController(AutotagController source) {
+        this.taggers = source.getTaggers().stream()
+                .map(JsonAdaptedSelectiveBookmarkTagger::new).collect(Collectors.toList());
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted autotag controller object
+     * into the model's {@code AutotagController} object.
+     */
+    public AutotagController toModelType() {
+        return new AutotagController(taggers.stream().map(
+                JsonAdaptedSelectiveBookmarkTagger::toModelType).collect(
+                Collectors.toList()));
+    }
+
+    @Override
+    public String toString() {
+        return taggers.toString();
+    }
+}

--- a/src/main/java/seedu/mark/storage/JsonAdaptedAutotagController.java
+++ b/src/main/java/seedu/mark/storage/JsonAdaptedAutotagController.java
@@ -43,9 +43,9 @@ public class JsonAdaptedAutotagController {
      * into the model's {@code AutotagController} object.
      */
     public AutotagController toModelType() {
-        return new AutotagController(taggers.stream().map(
-                JsonAdaptedSelectiveBookmarkTagger::toModelType).collect(
-                Collectors.toList()));
+        return new AutotagController(
+                taggers.stream().map(JsonAdaptedSelectiveBookmarkTagger::toModelType)
+                        .collect(Collectors.toList()));
     }
 
     @Override

--- a/src/main/java/seedu/mark/storage/JsonAdaptedBookmark.java
+++ b/src/main/java/seedu/mark/storage/JsonAdaptedBookmark.java
@@ -21,7 +21,7 @@ import seedu.mark.model.tag.Tag;
 /**
  * Jackson-friendly version of {@link Bookmark}.
  */
-class JsonAdaptedBookmark {
+public class JsonAdaptedBookmark {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Bookmark's %s field is missing!";
 

--- a/src/main/java/seedu/mark/storage/JsonAdaptedBookmarkPredicate.java
+++ b/src/main/java/seedu/mark/storage/JsonAdaptedBookmarkPredicate.java
@@ -11,7 +11,7 @@ import seedu.mark.model.predicates.BookmarkPredicate;
 /**
  * Jackson-friendly version of {@link BookmarkPredicate}.
  */
-class JsonAdaptedBookmarkPredicate {
+public class JsonAdaptedBookmarkPredicate {
 
     private final List<String> nameKeywords = new ArrayList<>();
     private final List<String> notNameKeywords = new ArrayList<>();

--- a/src/main/java/seedu/mark/storage/JsonAdaptedBookmarkPredicate.java
+++ b/src/main/java/seedu/mark/storage/JsonAdaptedBookmarkPredicate.java
@@ -22,14 +22,14 @@ class JsonAdaptedBookmarkPredicate {
      * Constructs a {@code JsonAdaptedBookmarkPredicate} with the given predicate details.
      */
     @JsonCreator
-    public JsonAdaptedBookmarkPredicate(@JsonProperty("name") List<String> name,
-                                        @JsonProperty("notName") List<String> notName,
-                                        @JsonProperty("url") List<String> url,
-                                        @JsonProperty("notUrl") List<String> notUrl) {
-        this.nameKeywords.addAll(name);
-        this.notNameKeywords.addAll(notName);
-        this.urlKeywords.addAll(url);
-        this.notUrlKeywords.addAll(notUrl);
+    public JsonAdaptedBookmarkPredicate(@JsonProperty("nameKeywords") List<String> nameKeywords,
+                                        @JsonProperty("notNameKeywords") List<String> notNameKeywords,
+                                        @JsonProperty("urlKeywords") List<String> urlKeywords,
+                                        @JsonProperty("notUrlKeywords") List<String> notUrlKeywords) {
+        this.nameKeywords.addAll(nameKeywords);
+        this.notNameKeywords.addAll(notNameKeywords);
+        this.urlKeywords.addAll(urlKeywords);
+        this.notUrlKeywords.addAll(notUrlKeywords);
     }
 
     /**

--- a/src/main/java/seedu/mark/storage/JsonAdaptedBookmarkPredicate.java
+++ b/src/main/java/seedu/mark/storage/JsonAdaptedBookmarkPredicate.java
@@ -1,0 +1,53 @@
+package seedu.mark.storage;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.mark.model.predicates.BookmarkPredicate;
+
+/**
+ * Jackson-friendly version of {@link BookmarkPredicate}.
+ */
+class JsonAdaptedBookmarkPredicate {
+
+    private final List<String> nameKeywords = new ArrayList<>();
+    private final List<String> notNameKeywords = new ArrayList<>();
+    private final List<String> urlKeywords = new ArrayList<>();
+    private final List<String> notUrlKeywords = new ArrayList<>();
+
+    /**
+     * Constructs a {@code JsonAdaptedBookmarkPredicate} with the given predicate details.
+     */
+    @JsonCreator
+    public JsonAdaptedBookmarkPredicate(@JsonProperty("name") List<String> name,
+                                        @JsonProperty("notName") List<String> notName,
+                                        @JsonProperty("url") List<String> url,
+                                        @JsonProperty("notUrl") List<String> notUrl) {
+        this.nameKeywords.addAll(name);
+        this.notNameKeywords.addAll(notName);
+        this.urlKeywords.addAll(url);
+        this.notUrlKeywords.addAll(notUrl);
+    }
+
+    /**
+     * Converts a given {@code BookmarkPredicate} into this class for Jackson use.
+     */
+    public JsonAdaptedBookmarkPredicate(BookmarkPredicate source) {
+        nameKeywords.addAll(source.getNameKeywords());
+        notNameKeywords.addAll(source.getNotNameKeywords());
+        urlKeywords.addAll(source.getUrlKeywords());
+        notUrlKeywords.addAll(source.getNotUrlKeywords());
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted bookmark object into the model's
+     * {@code BookmarkPredicate} object.
+     */
+    public BookmarkPredicate toModelType() {
+        return new BookmarkPredicate().withNameKeywords(nameKeywords).withoutNameKeywords(notNameKeywords)
+                .withUrlKeywords(urlKeywords).withoutUrlKeywords(notUrlKeywords);
+    }
+}

--- a/src/main/java/seedu/mark/storage/JsonAdaptedSelectiveBookmarkTagger.java
+++ b/src/main/java/seedu/mark/storage/JsonAdaptedSelectiveBookmarkTagger.java
@@ -9,7 +9,7 @@ import seedu.mark.model.tag.Tag;
 /**
  * Jackson-friendly version of {@link SelectiveBookmarkTagger}.
  */
-class JsonAdaptedSelectiveBookmarkTagger {
+public class JsonAdaptedSelectiveBookmarkTagger {
 
     private final String tag;
     private final JsonAdaptedBookmarkPredicate predicate;

--- a/src/main/java/seedu/mark/storage/JsonAdaptedSelectiveBookmarkTagger.java
+++ b/src/main/java/seedu/mark/storage/JsonAdaptedSelectiveBookmarkTagger.java
@@ -1,0 +1,42 @@
+package seedu.mark.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.mark.model.autotag.SelectiveBookmarkTagger;
+import seedu.mark.model.tag.Tag;
+
+/**
+ * Jackson-friendly version of {@link SelectiveBookmarkTagger}.
+ */
+class JsonAdaptedSelectiveBookmarkTagger {
+
+    private final String tag;
+    private final JsonAdaptedBookmarkPredicate predicate;
+
+    /**
+     * Constructs a {@code JsonAdaptedTag} with the given {@code conditions}.
+     */
+    @JsonCreator
+    public JsonAdaptedSelectiveBookmarkTagger(@JsonProperty("tag") String tag,
+                                              @JsonProperty("predicate") JsonAdaptedBookmarkPredicate predicate) {
+        this.tag = tag;
+        this.predicate = predicate;
+    }
+
+    /**
+     * Converts a given {@code SelectiveBookmarkTagger} into this class for Jackson use.
+     */
+    public JsonAdaptedSelectiveBookmarkTagger(SelectiveBookmarkTagger source) {
+        tag = source.getTagToApply().tagName;
+        predicate = new JsonAdaptedBookmarkPredicate(source.getPredicate());
+    }
+
+    /**
+     * Converts this Jackson-friendly adapted tag object into the model's {@code Tag} object.
+     */
+    public SelectiveBookmarkTagger toModelType() {
+        return new SelectiveBookmarkTagger(new Tag(tag), predicate.toModelType());
+    }
+
+}

--- a/src/main/java/seedu/mark/storage/JsonAdaptedTag.java
+++ b/src/main/java/seedu/mark/storage/JsonAdaptedTag.java
@@ -9,7 +9,7 @@ import seedu.mark.model.tag.Tag;
 /**
  * Jackson-friendly version of {@link Tag}.
  */
-class JsonAdaptedTag {
+public class JsonAdaptedTag {
 
     private final String tagName;
 

--- a/src/main/java/seedu/mark/storage/JsonSerializableMark.java
+++ b/src/main/java/seedu/mark/storage/JsonSerializableMark.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import seedu.mark.commons.exceptions.IllegalValueException;
 import seedu.mark.model.Mark;
 import seedu.mark.model.ReadOnlyMark;
+import seedu.mark.model.autotag.AutotagController;
 import seedu.mark.model.bookmark.Bookmark;
 import seedu.mark.model.bookmark.Folder;
 import seedu.mark.model.folderstructure.FolderStructure;
@@ -27,15 +28,18 @@ class JsonSerializableMark {
 
     private final List<JsonAdaptedBookmark> bookmarks = new ArrayList<>();
     private final JsonAdaptedFolderStructure folderStructure;
+    private final JsonAdaptedAutotagController autotagController;
 
     /**
      * Constructs a {@code JsonSerializableMark} with the given bookmarks.
      */
     @JsonCreator
     public JsonSerializableMark(@JsonProperty("bookmarks") List<JsonAdaptedBookmark> bookmarks,
-        @JsonProperty("folderStructure") JsonAdaptedFolderStructure folderStructure) {
+                                @JsonProperty("folderStructure") JsonAdaptedFolderStructure folderStructure,
+                                @JsonProperty("autotagController") JsonAdaptedAutotagController autotagController) {
         this.bookmarks.addAll(bookmarks);
         this.folderStructure = folderStructure;
+        this.autotagController = autotagController;
     }
 
     /**
@@ -48,6 +52,7 @@ class JsonSerializableMark {
         bookmarks.addAll(source.getBookmarkList().stream().map(JsonAdaptedBookmark::new)
             .collect(Collectors.toList()));
         folderStructure = new JsonAdaptedFolderStructure(source.getFolderStructure());
+        autotagController = new JsonAdaptedAutotagController(source.getAutotagController());
     }
 
     /**
@@ -64,6 +69,7 @@ class JsonSerializableMark {
             }
             mark.addBookmark(bookmark);
         }
+
         FolderStructure modelFolderStructure = folderStructure.toModelType();
         if (!modelFolderStructure.getFolder().equals(Folder.ROOT_FOLDER)) {
             throw new IllegalValueException(MESSAGE_NO_ROOT_FOLDER);
@@ -72,6 +78,12 @@ class JsonSerializableMark {
             throw new IllegalValueException(MESSAGE_DUPLICATE_FOLDER);
         }
         mark.setFolderStructure(modelFolderStructure);
+
+        if (autotagController == null) { // for backwards compatibility
+            mark.setAutotagController(new AutotagController());
+        } else {
+            mark.setAutotagController(autotagController.toModelType());
+        }
         return mark;
     }
 

--- a/src/main/java/seedu/mark/storage/JsonSerializableMark.java
+++ b/src/main/java/seedu/mark/storage/JsonSerializableMark.java
@@ -20,7 +20,7 @@ import seedu.mark.model.folderstructure.FolderStructure;
  * An Immutable Mark that is serializable to JSON format.
  */
 @JsonRootName(value = "mark")
-class JsonSerializableMark {
+public class JsonSerializableMark {
 
     public static final String MESSAGE_DUPLICATE_BOOKMARK = "Bookmark list contains duplicate bookmark(s).";
     public static final String MESSAGE_DUPLICATE_FOLDER = "There are duplicate folder(s).";

--- a/src/test/java/seedu/mark/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/AddCommandTest.java
@@ -66,6 +66,8 @@ public class AddCommandTest {
                 addCommand.execute(modelStub, new StorageStub()));
     }
 
+    // TODO: bookmark gets tagged by autotagController
+
     @Test
     public void equals() {
         Bookmark alice = new BookmarkBuilder().withName("Alice").build();

--- a/src/test/java/seedu/mark/logic/commands/AutotagCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/AutotagCommandTest.java
@@ -20,7 +20,7 @@ import seedu.mark.model.ModelManager;
 import seedu.mark.model.UserPrefs;
 import seedu.mark.model.autotag.SelectiveBookmarkTagger;
 import seedu.mark.model.bookmark.Bookmark;
-import seedu.mark.model.predicates.NameContainsKeywordsPredicate;
+import seedu.mark.model.predicates.BookmarkPredicate;
 import seedu.mark.model.tag.Tag;
 import seedu.mark.storage.Storage;
 import seedu.mark.storage.StorageStub;
@@ -62,7 +62,7 @@ public class AutotagCommandTest {
 
     @Test
     public void execute_taggerAlreadyExists_throwsException() {
-        NameContainsKeywordsPredicate predicate = prepareNamePredicate("zzz");
+        BookmarkPredicate predicate = prepareNamePredicate("zzz");
         SelectiveBookmarkTagger tagger = new SelectiveBookmarkTagger(new Tag("notTagged"), predicate);
         AutotagCommand command = new AutotagCommand(tagger);
 
@@ -78,7 +78,7 @@ public class AutotagCommandTest {
         // No bookmarks tagged
         Model model = new ModelManager(getTypicalMark(), new UserPrefs());
 
-        NameContainsKeywordsPredicate predicate = prepareNamePredicate("zzz");
+        BookmarkPredicate predicate = prepareNamePredicate("zzz");
         SelectiveBookmarkTagger tagger = new SelectiveBookmarkTagger(new Tag("notTagged"), predicate);
         AutotagCommand command = new AutotagCommand(tagger);
 
@@ -92,7 +92,7 @@ public class AutotagCommandTest {
     public void execute_newTaggerMatchesOneBookmark_successBookmarkTagged() {
         Model model = new ModelManager(getTypicalMark(), new UserPrefs());
 
-        NameContainsKeywordsPredicate predicate = prepareNamePredicate("Alice Pauline");
+        BookmarkPredicate predicate = prepareNamePredicate("Alice Pauline");
         SelectiveBookmarkTagger tagger = new SelectiveBookmarkTagger(new Tag("oneTagged"), predicate);
         AutotagCommand command = new AutotagCommand(tagger);
 
@@ -109,7 +109,7 @@ public class AutotagCommandTest {
     public void execute_newTaggerMatchesMultipleBookmarks_successBookmarksTagged() {
         Model model = new ModelManager(getTypicalMark(), new UserPrefs());
 
-        NameContainsKeywordsPredicate predicate = prepareNamePredicate("ku");
+        BookmarkPredicate predicate = prepareNamePredicate("ku");
         SelectiveBookmarkTagger tagger = new SelectiveBookmarkTagger(new Tag("namesContainKu"), predicate);
         AutotagCommand command = new AutotagCommand(tagger);
 
@@ -127,7 +127,7 @@ public class AutotagCommandTest {
     /**
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
      */
-    private NameContainsKeywordsPredicate prepareNamePredicate(String userInput) {
-        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    private BookmarkPredicate prepareNamePredicate(String userInput) {
+        return new BookmarkPredicate().withNameKeywords(Arrays.asList(userInput.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/mark/logic/commands/AutotagDeleteCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/AutotagDeleteCommandTest.java
@@ -1,0 +1,100 @@
+package seedu.mark.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.mark.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.mark.logic.commands.exceptions.CommandException;
+import seedu.mark.logic.commands.results.CommandResult;
+import seedu.mark.model.ModelStub;
+import seedu.mark.storage.Storage;
+import seedu.mark.storage.StorageStub;
+
+/**
+ * Contains unit tests for {@link AutotagDeleteCommand}.
+ */
+public class AutotagDeleteCommandTest {
+
+    private final Storage storageStub = new StorageStub();
+    private final String tagName = "myTag";
+
+    @Test
+    public void constructor_nullString_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AutotagDeleteCommand(null));
+    }
+
+    @Test
+    public void execute_taggerExistsInModel_deleteSuccessful() throws Exception {
+        CommandResult commandResult = new AutotagDeleteCommand(tagName)
+                .execute(new ModelStubWithAutotags(), storageStub);
+
+        assertEquals(String.format(AutotagDeleteCommand.MESSAGE_AUTOTAG_DELETED, tagName),
+                commandResult.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_duplicateBookmark_throwsCommandException() {
+        AutotagDeleteCommand autotagDeleteCommand = new AutotagDeleteCommand(tagName);
+        String expectedMessage = String.format(AutotagDeleteCommand.MESSAGE_AUTOTAG_DOES_NOT_EXIST, tagName);
+
+        assertThrows(CommandException.class, expectedMessage, () ->
+                autotagDeleteCommand.execute(new ModelStubNoAutotags(), storageStub));
+    }
+
+    @Test
+    public void equals() {
+        String quizTagName = "Quiz";
+        String readLaterTagName = "readLater";
+        AutotagDeleteCommand firstCommand = new AutotagDeleteCommand(quizTagName);
+        AutotagDeleteCommand secondCommand = new AutotagDeleteCommand(readLaterTagName);
+
+        // same object -> returns true
+        assertTrue(firstCommand.equals(firstCommand));
+
+        // same values -> returns true
+        AutotagDeleteCommand firstCommandCopy = new AutotagDeleteCommand(quizTagName);
+        assertTrue(firstCommand.equals(firstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(firstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(firstCommand.equals(null));
+
+        // different bookmark -> returns false
+        assertFalse(firstCommand.equals(secondCommand));
+    }
+
+    /**
+     * A Model stub that always returns true when attempting to remove a tagger.
+     */
+    private class ModelStubWithAutotags extends ModelStub {
+        @Override
+        public boolean removeTagger(String taggerName) {
+            return true;
+        }
+
+        @Override
+        public void saveMark(String record) {
+            // called in AutotagDeleteCommand#execute()
+        }
+    }
+
+    /**
+     * A Model stub that always returns false when attempting to remove a tagger.
+     */
+    private class ModelStubNoAutotags extends ModelStub {
+        @Override
+        public boolean removeTagger(String taggerName) {
+            return false;
+        }
+
+        @Override
+        public void saveMark(String record) {
+            // called in AutotagDeleteCommand#execute()
+        }
+    }
+}

--- a/src/test/java/seedu/mark/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/EditCommandTest.java
@@ -167,6 +167,8 @@ public class EditCommandTest {
         assertCommandFailure(editCommand, model, new StorageStub(), Messages.MESSAGE_INVALID_BOOKMARK_DISPLAYED_INDEX);
     }
 
+    // TODO: bookmark gets tagged by autotagController
+
     @Test
     public void equals() {
         final EditCommand standardCommand = new EditCommand(INDEX_FIRST_BOOKMARK, DESC_AMY);

--- a/src/test/java/seedu/mark/logic/parser/AutotagCommandParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/AutotagCommandParserTest.java
@@ -46,12 +46,14 @@ public class AutotagCommandParserTest {
 
         // no tag name and no condition specified
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+
+        // multiple tag names specified
+        assertParseFailure(parser, "two or more tags", MESSAGE_INVALID_FORMAT);
     }
 
     @Test
     public void parse_invalidValue_failure() {
         // invalid tag name
-        assertParseFailure(parser, "multiple words not allowed" + NAME_DESC_1, Tag.MESSAGE_CONSTRAINTS);
         assertParseFailure(parser, "non_alphanumeric_characters" + NAME_DESC_1, Tag.MESSAGE_CONSTRAINTS);
 
         // TODO: Reject invalid names/URLs as conditions in AutotagCommandParser

--- a/src/test/java/seedu/mark/logic/parser/AutotagCommandParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/AutotagCommandParserTest.java
@@ -1,7 +1,6 @@
 package seedu.mark.logic.parser;
 
 import static seedu.mark.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.mark.logic.parser.AutotagCommandParser.DEFAULT_PREDICATE;
 import static seedu.mark.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.mark.logic.parser.CliSyntax.PREFIX_NOT_NAME;
 import static seedu.mark.logic.parser.CliSyntax.PREFIX_NOT_URL;
@@ -22,6 +21,8 @@ import seedu.mark.model.predicates.UrlContainsKeywordsPredicate;
 import seedu.mark.model.tag.Tag;
 
 public class AutotagCommandParserTest {
+
+    public static final Predicate<Bookmark> DEFAULT_PREDICATE = bookmark -> true;
 
     private static final String VALID_TAG = "myTag";
     private static final String VALID_NAME_1 = "website";

--- a/src/test/java/seedu/mark/logic/parser/AutotagCommandParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/AutotagCommandParserTest.java
@@ -10,21 +10,15 @@ import static seedu.mark.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.mark.logic.commands.AutotagCommand;
 import seedu.mark.model.autotag.SelectiveBookmarkTagger;
-import seedu.mark.model.bookmark.Bookmark;
 import seedu.mark.model.predicates.BookmarkPredicate;
-import seedu.mark.model.predicates.NameContainsKeywordsPredicate;
-import seedu.mark.model.predicates.UrlContainsKeywordsPredicate;
 import seedu.mark.model.tag.Tag;
 
 public class AutotagCommandParserTest {
-
-    public static final Predicate<Bookmark> DEFAULT_PREDICATE = bookmark -> true;
 
     private static final String VALID_TAG = "myTag";
     private static final String VALID_NAME_1 = "website";
@@ -67,10 +61,6 @@ public class AutotagCommandParserTest {
     public void parse_allFieldsSpecified_success() {
         String userInput = VALID_TAG + NAME_DESC_1 + URL_DESC_1;
 
-        NameContainsKeywordsPredicate namePredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList(VALID_NAME_1));
-        UrlContainsKeywordsPredicate urlPredicate =
-                new UrlContainsKeywordsPredicate(Collections.singletonList(VALID_URL_1));
         AutotagCommand expectedCommand = new AutotagCommand(new SelectiveBookmarkTagger(new Tag(VALID_TAG),
                 new BookmarkPredicate().withNameKeywords(Collections.singletonList(VALID_NAME_1))
                         .withUrlKeywords(Collections.singletonList(VALID_URL_1))));

--- a/src/test/java/seedu/mark/logic/parser/AutotagCommandParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/AutotagCommandParserTest.java
@@ -9,6 +9,7 @@ import static seedu.mark.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.mark.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import seedu.mark.logic.commands.AutotagCommand;
 import seedu.mark.model.autotag.SelectiveBookmarkTagger;
 import seedu.mark.model.bookmark.Bookmark;
+import seedu.mark.model.predicates.BookmarkPredicate;
 import seedu.mark.model.predicates.NameContainsKeywordsPredicate;
 import seedu.mark.model.predicates.UrlContainsKeywordsPredicate;
 import seedu.mark.model.tag.Tag;
@@ -65,10 +67,13 @@ public class AutotagCommandParserTest {
     public void parse_allFieldsSpecified_success() {
         String userInput = VALID_TAG + NAME_DESC_1 + URL_DESC_1;
 
-        NameContainsKeywordsPredicate namePredicate = new NameContainsKeywordsPredicate(Arrays.asList(VALID_NAME_1));
-        UrlContainsKeywordsPredicate urlPredicate = new UrlContainsKeywordsPredicate(Arrays.asList(VALID_URL_1));
+        NameContainsKeywordsPredicate namePredicate =
+                new NameContainsKeywordsPredicate(Collections.singletonList(VALID_NAME_1));
+        UrlContainsKeywordsPredicate urlPredicate =
+                new UrlContainsKeywordsPredicate(Collections.singletonList(VALID_URL_1));
         AutotagCommand expectedCommand = new AutotagCommand(new SelectiveBookmarkTagger(new Tag(VALID_TAG),
-                DEFAULT_PREDICATE.and(namePredicate).and(urlPredicate)));
+                new BookmarkPredicate().withNameKeywords(Collections.singletonList(VALID_NAME_1))
+                        .withUrlKeywords(Collections.singletonList(VALID_URL_1))));
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -77,33 +82,33 @@ public class AutotagCommandParserTest {
     public void parse_oneFieldSpecified_success() {
         // url
         String userInput = VALID_TAG + URL_DESC_1;
-        Predicate<Bookmark> predicate = new UrlContainsKeywordsPredicate(Arrays.asList(VALID_URL_1));
         AutotagCommand expectedCommand = new AutotagCommand(
-                new SelectiveBookmarkTagger(new Tag(VALID_TAG), DEFAULT_PREDICATE.and(predicate)));
+                new SelectiveBookmarkTagger(new Tag(VALID_TAG),
+                        new BookmarkPredicate().withUrlKeywords(Collections.singletonList(VALID_URL_1))));
 
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // name
         userInput = VALID_TAG + NAME_DESC_1;
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList(VALID_NAME_1));
         expectedCommand = new AutotagCommand(
-                new SelectiveBookmarkTagger(new Tag(VALID_TAG), DEFAULT_PREDICATE.and(predicate)));
+                new SelectiveBookmarkTagger(new Tag(VALID_TAG),
+                        new BookmarkPredicate().withNameKeywords(Collections.singletonList(VALID_NAME_1))));
 
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // not name
         userInput = VALID_TAG + NOT_NAME_DESC_1;
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList(VALID_NAME_1)).negate();
         expectedCommand = new AutotagCommand(
-                new SelectiveBookmarkTagger(new Tag(VALID_TAG), DEFAULT_PREDICATE.and(predicate)));
+                new SelectiveBookmarkTagger(new Tag(VALID_TAG),
+                        new BookmarkPredicate().withoutNameKeywords(Collections.singletonList(VALID_NAME_1))));
 
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // not url
         userInput = VALID_TAG + NOT_URL_DESC_1;
-        predicate = new UrlContainsKeywordsPredicate(Arrays.asList(VALID_URL_1)).negate();
         expectedCommand = new AutotagCommand(
-                new SelectiveBookmarkTagger(new Tag(VALID_TAG), DEFAULT_PREDICATE.and(predicate)));
+                new SelectiveBookmarkTagger(new Tag(VALID_TAG),
+                        new BookmarkPredicate().withoutUrlKeywords(Collections.singletonList(VALID_URL_1))));
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -112,10 +117,9 @@ public class AutotagCommandParserTest {
     public void parse_repeatedFields_success() {
         String userInput = VALID_TAG + NAME_DESC_1 + NAME_DESC_2;
 
-        NameContainsKeywordsPredicate namePredicate =
-                new NameContainsKeywordsPredicate(Arrays.asList(VALID_NAME_1, VALID_NAME_2));
         AutotagCommand expectedCommand = new AutotagCommand(
-                new SelectiveBookmarkTagger(new Tag(VALID_TAG), DEFAULT_PREDICATE.and(namePredicate)));
+                new SelectiveBookmarkTagger(new Tag(VALID_TAG),
+                        new BookmarkPredicate().withNameKeywords(Arrays.asList(VALID_NAME_1, VALID_NAME_2))));
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }

--- a/src/test/java/seedu/mark/logic/parser/AutotagCommandParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/AutotagCommandParserTest.java
@@ -44,6 +44,9 @@ public class AutotagCommandParserTest {
         // no condition specified
         assertParseFailure(parser, VALID_TAG, AutotagCommand.MESSAGE_NO_CONDITION_SPECIFIED);
 
+        // empty condition
+        assertParseFailure(parser, VALID_TAG + " " + PREFIX_URL, AutotagCommand.MESSAGE_CONDITION_EMPTY);
+
         // no tag name and no condition specified
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
 

--- a/src/test/java/seedu/mark/logic/parser/AutotagDeleteCommandParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/AutotagDeleteCommandParserTest.java
@@ -1,0 +1,27 @@
+package seedu.mark.logic.parser;
+
+import static seedu.mark.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.mark.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.mark.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.mark.logic.commands.AutotagDeleteCommand;
+
+public class AutotagDeleteCommandParserTest {
+
+    private final AutotagDeleteCommandParser parser = new AutotagDeleteCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsAutotagDeleteCommand() {
+        assertParseSuccess(parser, "myTag", new AutotagDeleteCommand("myTag"));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AutotagDeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "multiple tagNames not allowed",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AutotagDeleteCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/mark/logic/parser/MarkParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/MarkParserTest.java
@@ -38,8 +38,8 @@ import seedu.mark.logic.parser.exceptions.ParseException;
 import seedu.mark.model.autotag.SelectiveBookmarkTagger;
 import seedu.mark.model.bookmark.Bookmark;
 import seedu.mark.model.bookmark.Folder;
+import seedu.mark.model.predicates.BookmarkPredicate;
 import seedu.mark.model.predicates.IdentifiersContainKeywordsPredicate;
-import seedu.mark.model.predicates.NameContainsKeywordsPredicate;
 import seedu.mark.model.tag.Tag;
 import seedu.mark.testutil.BookmarkBuilder;
 import seedu.mark.testutil.BookmarkUtil;
@@ -68,7 +68,7 @@ public class MarkParserTest {
         AutotagCommand command = (AutotagCommand) parser.parseCommand(
                 AutotagCommand.COMMAND_WORD + " " + VALID_TAG_FRIEND + NAME_DESC_AMY);
         AutotagCommand expectedCommand = new AutotagCommand(new SelectiveBookmarkTagger(new Tag(VALID_TAG_FRIEND),
-                new NameContainsKeywordsPredicate(Arrays.asList(VALID_NAME_AMY))));
+                new BookmarkPredicate().withNameKeywords(Arrays.asList(VALID_NAME_AMY))));
         assertEquals(command, expectedCommand);
     }
 

--- a/src/test/java/seedu/mark/logic/parser/MarkParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/MarkParserTest.java
@@ -95,27 +95,6 @@ public class MarkParserTest {
     }
 
     @Test
-    public void parseCommand_favorite() throws Exception {
-        FavoriteCommand command = (FavoriteCommand) parser.parseCommand(
-                FavoriteCommand.COMMAND_WORD + " " + INDEX_FIRST_BOOKMARK.getOneBased());
-        assertEquals(new FavoriteCommand(INDEX_FIRST_BOOKMARK), command);
-    }
-
-    @Test
-    public void parseCommand_favoriteAlias() throws Exception {
-        FavoriteCommand command = (FavoriteCommand) parser.parseCommand(
-                FavoriteCommand.COMMAND_ALIAS + " " + INDEX_FIRST_BOOKMARK.getOneBased());
-        assertEquals(new FavoriteCommand(INDEX_FIRST_BOOKMARK), command);
-    }
-
-    @Test
-    public void parseCommand_goto() throws Exception {
-        GotoCommand command = (GotoCommand) parser.parseCommand(
-                GotoCommand.COMMAND_WORD + " " + INDEX_FIRST_BOOKMARK.getOneBased());
-        assertEquals(new GotoCommand(INDEX_FIRST_BOOKMARK), command);
-    }
-
-    @Test
     public void parseCommand_edit() throws Exception {
         Bookmark bookmark = new BookmarkBuilder().build();
         EditCommand.EditBookmarkDescriptor descriptor = new EditBookmarkDescriptorBuilder(bookmark).build();
@@ -140,11 +119,17 @@ public class MarkParserTest {
     }
 
     @Test
-    public void parseCommand_import() throws Exception {
-        // assumption: bookmarks are imported from the folder data/bookmarks/ (see ImportCommandParser)
-        String fileName = "myBookmarks";
-        ImportCommand command = (ImportCommand) parser.parseCommand(ImportCommand.COMMAND_WORD + " " + fileName);
-        assertEquals(new ImportCommand(Path.of("data", "bookmarks", fileName + ".json")), command);
+    public void parseCommand_favorite() throws Exception {
+        FavoriteCommand command = (FavoriteCommand) parser.parseCommand(
+                FavoriteCommand.COMMAND_WORD + " " + INDEX_FIRST_BOOKMARK.getOneBased());
+        assertEquals(new FavoriteCommand(INDEX_FIRST_BOOKMARK), command);
+    }
+
+    @Test
+    public void parseCommand_favoriteAlias() throws Exception {
+        FavoriteCommand command = (FavoriteCommand) parser.parseCommand(
+                FavoriteCommand.COMMAND_ALIAS + " " + INDEX_FIRST_BOOKMARK.getOneBased());
+        assertEquals(new FavoriteCommand(INDEX_FIRST_BOOKMARK), command);
     }
 
     @Test
@@ -156,9 +141,24 @@ public class MarkParserTest {
     }
 
     @Test
+    public void parseCommand_goto() throws Exception {
+        GotoCommand command = (GotoCommand) parser.parseCommand(
+                GotoCommand.COMMAND_WORD + " " + INDEX_FIRST_BOOKMARK.getOneBased());
+        assertEquals(new GotoCommand(INDEX_FIRST_BOOKMARK), command);
+    }
+
+    @Test
     public void parseCommand_help() throws Exception {
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
         assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
+    }
+
+    @Test
+    public void parseCommand_import() throws Exception {
+        // assumption: bookmarks are imported from the folder data/bookmarks/ (see ImportCommandParser)
+        String fileName = "myBookmarks";
+        ImportCommand command = (ImportCommand) parser.parseCommand(ImportCommand.COMMAND_WORD + " " + fileName);
+        assertEquals(new ImportCommand(Path.of("data", "bookmarks", fileName + ".json")), command);
     }
 
     @Test
@@ -168,15 +168,15 @@ public class MarkParserTest {
     }
 
     @Test
-    public void parseCommand_undo() throws Exception {
-        assertTrue(parser.parseCommand(UndoCommand.COMMAND_WORD) instanceof UndoCommand);
-        assertTrue(parser.parseCommand(UndoCommand.COMMAND_WORD + " 3") instanceof UndoCommand);
-    }
-
-    @Test
     public void parseCommand_redo() throws Exception {
         assertTrue(parser.parseCommand(RedoCommand.COMMAND_WORD) instanceof RedoCommand);
         assertTrue(parser.parseCommand(RedoCommand.COMMAND_WORD + " 3") instanceof RedoCommand);
+    }
+
+    @Test
+    public void parseCommand_undo() throws Exception {
+        assertTrue(parser.parseCommand(UndoCommand.COMMAND_WORD) instanceof UndoCommand);
+        assertTrue(parser.parseCommand(UndoCommand.COMMAND_WORD + " 3") instanceof UndoCommand);
     }
 
     @Test

--- a/src/test/java/seedu/mark/logic/parser/MarkParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/MarkParserTest.java
@@ -43,7 +43,6 @@ import seedu.mark.model.bookmark.Folder;
 import seedu.mark.model.bookmark.util.BookmarkBuilder;
 import seedu.mark.model.predicates.BookmarkContainsKeywordsPredicate;
 import seedu.mark.model.predicates.BookmarkPredicate;
-import seedu.mark.model.predicates.NameContainsKeywordsPredicate;
 import seedu.mark.model.tag.Tag;
 import seedu.mark.testutil.BookmarkUtil;
 import seedu.mark.testutil.EditBookmarkDescriptorBuilder;

--- a/src/test/java/seedu/mark/logic/parser/MarkParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/MarkParserTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import seedu.mark.logic.commands.AddCommand;
 import seedu.mark.logic.commands.AddFolderCommand;
 import seedu.mark.logic.commands.AutotagCommand;
+import seedu.mark.logic.commands.AutotagDeleteCommand;
 import seedu.mark.logic.commands.ClearCommand;
 import seedu.mark.logic.commands.DeleteCommand;
 import seedu.mark.logic.commands.EditCommand;
@@ -69,6 +70,14 @@ public class MarkParserTest {
                 AutotagCommand.COMMAND_WORD + " " + VALID_TAG_FRIEND + NAME_DESC_AMY);
         AutotagCommand expectedCommand = new AutotagCommand(new SelectiveBookmarkTagger(new Tag(VALID_TAG_FRIEND),
                 new BookmarkPredicate().withNameKeywords(Arrays.asList(VALID_NAME_AMY))));
+        assertEquals(command, expectedCommand);
+    }
+
+    @Test
+    public void parseCommand_autotagDelete() throws Exception {
+        AutotagDeleteCommand command = (AutotagDeleteCommand) parser.parseCommand(
+                AutotagDeleteCommand.COMMAND_WORD + " myTag");
+        AutotagDeleteCommand expectedCommand = new AutotagDeleteCommand("myTag");
         assertEquals(command, expectedCommand);
     }
 

--- a/src/test/java/seedu/mark/model/ModelStub.java
+++ b/src/test/java/seedu/mark/model/ModelStub.java
@@ -127,6 +127,11 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public boolean removeTagger(String taggerName) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public void applyAllTaggers() {
         throw new AssertionError("This method should not be called.");
     }

--- a/src/test/java/seedu/mark/model/autotag/AutotagControllerTest.java
+++ b/src/test/java/seedu/mark/model/autotag/AutotagControllerTest.java
@@ -13,19 +13,18 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import seedu.mark.model.bookmark.Bookmark;
-import seedu.mark.model.predicates.NameContainsKeywordsPredicate;
-import seedu.mark.model.predicates.UrlContainsKeywordsPredicate;
+import seedu.mark.model.predicates.BookmarkPredicate;
 import seedu.mark.model.tag.Tag;
 import seedu.mark.testutil.BookmarkBuilder;
 
 class AutotagControllerTest {
 
     private static final SelectiveBookmarkTagger TAGGER_HELLO = new SelectiveBookmarkTagger(
-            new Tag("Hello"), new NameContainsKeywordsPredicate(Collections.singletonList("hello")));
+            new Tag("Hello"), new BookmarkPredicate().withNameKeywords(Collections.singletonList("hello")));
     private static final SelectiveBookmarkTagger TAGGER_WORLD = new SelectiveBookmarkTagger(
-            new Tag("World"), new NameContainsKeywordsPredicate(Collections.singletonList("world")));
+            new Tag("World"), new BookmarkPredicate().withNameKeywords(Collections.singletonList("world")));
     private static final SelectiveBookmarkTagger TAGGER_URL_EXAMPLE = new SelectiveBookmarkTagger(
-            new Tag("exampleTag"), new UrlContainsKeywordsPredicate(Collections.singletonList("example")));
+            new Tag("exampleTag"), new BookmarkPredicate().withUrlKeywords(Collections.singletonList("example")));
 
     private static final Bookmark BOOKMARK_HELLO = new BookmarkBuilder().withName("Hello World")
             .withUrl("https://hello-world.org").build();

--- a/src/test/java/seedu/mark/model/autotag/SelectiveBookmarkTaggerTest.java
+++ b/src/test/java/seedu/mark/model/autotag/SelectiveBookmarkTaggerTest.java
@@ -3,20 +3,19 @@ package seedu.mark.model.autotag;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.mark.model.bookmark.Bookmark;
-import seedu.mark.model.predicates.NameContainsKeywordsPredicate;
+import seedu.mark.model.predicates.BookmarkPredicate;
 import seedu.mark.model.tag.Tag;
 import seedu.mark.testutil.BookmarkBuilder;
 
 class SelectiveBookmarkTaggerTest {
 
     private static final Tag SAMPLE_TAG = new Tag("myTag");
-    private static final Predicate<Bookmark> NAME_PREDICATE_HELLO =
-            new NameContainsKeywordsPredicate(Arrays.asList("hello"));
+    private static final BookmarkPredicate NAME_PREDICATE_HELLO =
+            new BookmarkPredicate().withNameKeywords(Arrays.asList("hello"));
 
     @Test
     public void applyTagSelectively_bookmarkMatches_returnTaggedBookmark() {

--- a/src/test/java/seedu/mark/model/bookmark/UrlTest.java
+++ b/src/test/java/seedu/mark/model/bookmark/UrlTest.java
@@ -28,9 +28,11 @@ public class UrlTest {
         assertFalse(Url.isValidUrl("")); // empty string
         assertFalse(Url.isValidUrl(" ")); // spaces only
 
-        // invalid compulsory parts
+        // invalid scheme
         assertFalse(Url.isValidUrl("example.com")); // missing scheme
         assertFalse(Url.isValidUrl("abc://example.com")); // invalid scheme
+
+        // invalid authority
         assertFalse(Url.isValidUrl("https://")); // missing authority
         assertFalse(Url.isValidUrl("https://a")); // authority too short
         assertFalse(Url.isValidUrl("https://.example.com")); // authority starts with a period
@@ -38,16 +40,13 @@ public class UrlTest {
         assertFalse(Url.isValidUrl(" http://peterjack.example.com")); // leading space
         assertFalse(Url.isValidUrl("https://peterjack.example.com ")); // trailing space
         assertFalse(Url.isValidUrl("https://peter jack.example.com")); // spaces in authority
-        assertFalse(Url.isValidUrl("https://example?.com/path?query")); // '?' symbol in authority
 
         // invalid optional parts
         assertFalse(Url.isValidUrl("https://example.com//")); // empty path segment
         assertFalse(Url.isValidUrl("https://example.com?")); // empty query
         assertFalse(Url.isValidUrl("https://example.com#")); // empty fragment
-        assertFalse(Url.isValidUrl("https://example.com??example")); // double '?' symbol
         assertFalse(Url.isValidUrl("https://example.com##example")); // double '#' symbol
         assertFalse(Url.isValidUrl("https://example.com#example1#example")); // double fragment
-        assertFalse(Url.isValidUrl("https://example.com#example1?example")); // fragment before query
 
         // valid url scheme
         assertTrue(Url.isValidUrl("http://example.com"));
@@ -78,7 +77,7 @@ public class UrlTest {
         // valid url - special characters
         assertTrue(Url.isValidUrl("http://!$&'*+,;=:()@-_.~")); // special characters in authority
         assertTrue(Url.isValidUrl("https://example.com/!$&'*+,;=:()@-_~.")); // special characters in path
-        assertTrue(Url.isValidUrl("https://example.com?!$&'*+,;=:()@-_~.")); // special characters in query
-        assertTrue(Url.isValidUrl("https://example.com#!$&'*+,;=:()@-_~.")); // special characters in response
+        assertTrue(Url.isValidUrl("https://example.com?!$&'*+,;=:()@-_~./?")); // special characters in query
+        assertTrue(Url.isValidUrl("https://example.com#!$&'*+,;=:()@-_~./?")); // special characters in response
     }
 }

--- a/src/test/java/seedu/mark/model/bookmark/UrlTest.java
+++ b/src/test/java/seedu/mark/model/bookmark/UrlTest.java
@@ -20,10 +20,12 @@ public class UrlTest {
     }
 
     @Test
-    public void isValidUrl() {
-        // null url
+    public void isValidUrl_nullUrl_throwsException() {
         assertThrows(NullPointerException.class, () -> Url.isValidUrl(null));
+    }
 
+    @Test
+    public void isValidUrl_invalidUrl_returnsFalse() {
         // blank url
         assertFalse(Url.isValidUrl("")); // empty string
         assertFalse(Url.isValidUrl(" ")); // spaces only
@@ -47,7 +49,10 @@ public class UrlTest {
         assertFalse(Url.isValidUrl("https://example.com#")); // empty fragment
         assertFalse(Url.isValidUrl("https://example.com##example")); // double '#' symbol
         assertFalse(Url.isValidUrl("https://example.com#example1#example")); // double fragment
+    }
 
+    @Test
+    public void isValidUrl_validUrl_returnsTrue() {
         // valid url scheme
         assertTrue(Url.isValidUrl("http://example.com"));
         assertTrue(Url.isValidUrl("https://example.com"));
@@ -79,5 +84,6 @@ public class UrlTest {
         assertTrue(Url.isValidUrl("https://example.com/!$&'*+,;=:()@-_~.")); // special characters in path
         assertTrue(Url.isValidUrl("https://example.com?!$&'*+,;=:()@-_~./?")); // special characters in query
         assertTrue(Url.isValidUrl("https://example.com#!$&'*+,;=:()@-_~./?")); // special characters in response
+        // TODO: check that encoded characters (%FF) are marked as valid
     }
 }

--- a/src/test/java/seedu/mark/model/bookmark/UrlTest.java
+++ b/src/test/java/seedu/mark/model/bookmark/UrlTest.java
@@ -49,6 +49,10 @@ public class UrlTest {
         assertFalse(Url.isValidUrl("https://example.com#")); // empty fragment
         assertFalse(Url.isValidUrl("https://example.com##example")); // double '#' symbol
         assertFalse(Url.isValidUrl("https://example.com#example1#example")); // double fragment
+
+        // invalid characters
+        assertFalse(Url.isValidUrl("https://example.com/%")); // '%' without hexadecimal characters
+        assertFalse(Url.isValidUrl("https://example.com/%Gz")); // invalid hexadecimal characters
     }
 
     @Test
@@ -84,6 +88,6 @@ public class UrlTest {
         assertTrue(Url.isValidUrl("https://example.com/!$&'*+,;=:()@-_~.")); // special characters in path
         assertTrue(Url.isValidUrl("https://example.com?!$&'*+,;=:()@-_~./?")); // special characters in query
         assertTrue(Url.isValidUrl("https://example.com#!$&'*+,;=:()@-_~./?")); // special characters in response
-        // TODO: check that encoded characters (%FF) are marked as valid
+        assertTrue(Url.isValidUrl("https://example.com/%FF-%12-%1a")); // hexadecimal encoded characters
     }
 }

--- a/src/test/java/seedu/mark/model/predicates/BookmarkPredicateTest.java
+++ b/src/test/java/seedu/mark/model/predicates/BookmarkPredicateTest.java
@@ -1,0 +1,36 @@
+package seedu.mark.model.predicates;
+
+import org.junit.jupiter.api.Test;
+
+class BookmarkPredicateTest {
+
+    // TODO: write tests
+
+    @Test
+    void test() {
+    }
+
+    @Test
+    void isEmpty() {
+    }
+
+    @Test
+    void withNameKeywords() {
+    }
+
+    @Test
+    void withoutNameKeywords() {
+    }
+
+    @Test
+    void withUrlKeywords() {
+    }
+
+    @Test
+    void withoutUrlKeywords() {
+    }
+
+    @Test
+    void testEquals() {
+    }
+}

--- a/src/test/java/seedu/mark/model/predicates/BookmarkPredicateTest.java
+++ b/src/test/java/seedu/mark/model/predicates/BookmarkPredicateTest.java
@@ -20,7 +20,7 @@ public class BookmarkPredicateTest {
     private static final List<String> KEYWORD_LIST_SINGLE = Collections.singletonList("second");
 
     @Test
-    void equals() {
+    public void equals() {
         BookmarkPredicate firstPredicate = new BookmarkPredicate().withNameKeywords(KEYWORD_LIST_MULTIPLE);
 
         // same object -> returns true
@@ -47,7 +47,7 @@ public class BookmarkPredicateTest {
     }
 
     @Test
-    void test() { // TODO: check equivalence partitions
+    public void test() { // TODO: check equivalence partitions
         Bookmark firstBookmark = new BookmarkBuilder().withName("First").withUrl("https://first.example.com").build();
         Bookmark secondBookmark =
                 new BookmarkBuilder().withName("Second").withUrl("https://second.example.com").build();
@@ -78,7 +78,7 @@ public class BookmarkPredicateTest {
     }
 
     @Test
-    void isEmpty() {
+    public void isEmpty() {
         assertTrue(new BookmarkPredicate().isEmpty());
         assertFalse(new BookmarkPredicate().withNameKeywords(KEYWORD_LIST_MULTIPLE).isEmpty());
         assertFalse(new BookmarkPredicate().withUrlKeywords(KEYWORD_LIST_MULTIPLE).isEmpty());
@@ -92,7 +92,7 @@ public class BookmarkPredicateTest {
     // correctness of predicate is tested in #test().
 
     @Test
-    void withNameKeywords_noDuplicateKeywords_success() {
+    public void withNameKeywords_noDuplicateKeywords_success() {
         BookmarkPredicate predicate = new BookmarkPredicate().withNameKeywords(KEYWORD_LIST_MULTIPLE);
         assertEquals(predicate.getNameKeywords(), new HashSet<>(KEYWORD_LIST_MULTIPLE));
         assertEquals(predicate.getNotNameKeywords(), new HashSet<>());
@@ -101,7 +101,7 @@ public class BookmarkPredicateTest {
     }
 
     @Test
-    void withoutNameKeywords_noDuplicateKeywords_success() {
+    public void withoutNameKeywords_noDuplicateKeywords_success() {
         BookmarkPredicate predicate = new BookmarkPredicate().withoutNameKeywords(KEYWORD_LIST_MULTIPLE);
         assertEquals(predicate.getNameKeywords(), new HashSet<>());
         assertEquals(predicate.getNotNameKeywords(), new HashSet<>(KEYWORD_LIST_MULTIPLE));
@@ -110,7 +110,7 @@ public class BookmarkPredicateTest {
     }
 
     @Test
-    void withUrlKeywords_noDuplicateKeywords_success() {
+    public void withUrlKeywords_noDuplicateKeywords_success() {
         BookmarkPredicate predicate = new BookmarkPredicate().withUrlKeywords(KEYWORD_LIST_MULTIPLE);
         assertEquals(predicate.getNameKeywords(), new HashSet<>());
         assertEquals(predicate.getNotNameKeywords(), new HashSet<>());
@@ -119,7 +119,7 @@ public class BookmarkPredicateTest {
     }
 
     @Test
-    void withoutUrlKeywords_noDuplicateKeywords_success() {
+    public void withoutUrlKeywords_noDuplicateKeywords_success() {
         BookmarkPredicate predicate = new BookmarkPredicate().withoutUrlKeywords(KEYWORD_LIST_MULTIPLE);
         assertEquals(predicate.getNameKeywords(), new HashSet<>());
         assertEquals(predicate.getNotNameKeywords(), new HashSet<>());

--- a/src/test/java/seedu/mark/model/predicates/BookmarkPredicateTest.java
+++ b/src/test/java/seedu/mark/model/predicates/BookmarkPredicateTest.java
@@ -1,36 +1,129 @@
 package seedu.mark.model.predicates;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
-class BookmarkPredicateTest {
+import seedu.mark.model.bookmark.Bookmark;
+import seedu.mark.testutil.BookmarkBuilder;
 
-    // TODO: write tests
+public class BookmarkPredicateTest {
+
+    private static final List<String> KEYWORD_LIST_MULTIPLE = Arrays.asList("first", "second");
+    private static final List<String> KEYWORD_LIST_SINGLE = Collections.singletonList("second");
 
     @Test
-    void test() {
+    void equals() {
+        BookmarkPredicate firstPredicate = new BookmarkPredicate().withNameKeywords(KEYWORD_LIST_MULTIPLE);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        BookmarkPredicate firstPredicateCopy = new BookmarkPredicate().withNameKeywords(KEYWORD_LIST_MULTIPLE);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different keywords -> returns false
+        assertFalse(firstPredicate.equals(new BookmarkPredicate())); // different name keywords
+        assertFalse(firstPredicate.equals(new BookmarkPredicate().withNameKeywords(KEYWORD_LIST_MULTIPLE)
+                        .withoutNameKeywords(KEYWORD_LIST_SINGLE))); // different not-name keywords
+        assertFalse(firstPredicate.equals(new BookmarkPredicate().withNameKeywords(KEYWORD_LIST_MULTIPLE)
+                        .withUrlKeywords(KEYWORD_LIST_SINGLE))); // different url keywords
+        assertFalse(firstPredicate.equals(new BookmarkPredicate().withNameKeywords(KEYWORD_LIST_MULTIPLE)
+                        .withoutUrlKeywords(KEYWORD_LIST_MULTIPLE))); // different not-url keywords
+    }
+
+    @Test
+    void test() { // TODO: check equivalence partitions
+        Bookmark firstBookmark = new BookmarkBuilder().withName("First").withUrl("https://first.example.com").build();
+        Bookmark secondBookmark =
+                new BookmarkBuilder().withName("Second").withUrl("https://second.example.com").build();
+
+        // empty predicate
+        BookmarkPredicate predicate = new BookmarkPredicate();
+        assertTrue(predicate.test(firstBookmark));
+        assertTrue(predicate.test(secondBookmark));
+
+        // some fields specified
+        predicate = new BookmarkPredicate().withNameKeywords(KEYWORD_LIST_MULTIPLE)
+                .withUrlKeywords(KEYWORD_LIST_SINGLE);
+        assertTrue(predicate.test(secondBookmark));
+        assertFalse(predicate.test(firstBookmark)); // url doesn't contain "second"
+
+        // all fields specified
+        predicate = new BookmarkPredicate().withNameKeywords(KEYWORD_LIST_MULTIPLE)
+                .withoutNameKeywords(KEYWORD_LIST_SINGLE).withUrlKeywords(KEYWORD_LIST_MULTIPLE)
+                .withoutUrlKeywords(KEYWORD_LIST_SINGLE);
+        assertTrue(predicate.test(firstBookmark));
+        assertFalse(predicate.test(secondBookmark));
+
+        // contradictory conditions
+        predicate = new BookmarkPredicate().withNameKeywords(KEYWORD_LIST_MULTIPLE)
+                .withoutNameKeywords(KEYWORD_LIST_MULTIPLE);
+        assertFalse(predicate.test(firstBookmark));
+        assertFalse(predicate.test(secondBookmark));
     }
 
     @Test
     void isEmpty() {
+        assertTrue(new BookmarkPredicate().isEmpty());
+        assertFalse(new BookmarkPredicate().withNameKeywords(KEYWORD_LIST_MULTIPLE).isEmpty());
+        assertFalse(new BookmarkPredicate().withUrlKeywords(KEYWORD_LIST_MULTIPLE).isEmpty());
+        assertFalse(new BookmarkPredicate().withoutNameKeywords(KEYWORD_LIST_MULTIPLE).isEmpty());
+        assertFalse(new BookmarkPredicate().withoutUrlKeywords(KEYWORD_LIST_MULTIPLE).isEmpty());
+    }
+
+    // TODO: test for invalid inputs / duplicate keywords
+
+    // NOTE: the following tests only check whether keyword sets are updated correctly.
+    // correctness of predicate is tested in #test().
+
+    @Test
+    void withNameKeywords_noDuplicateKeywords_success() {
+        BookmarkPredicate predicate = new BookmarkPredicate().withNameKeywords(KEYWORD_LIST_MULTIPLE);
+        assertEquals(predicate.getNameKeywords(), new HashSet<>(KEYWORD_LIST_MULTIPLE));
+        assertEquals(predicate.getNotNameKeywords(), new HashSet<>());
+        assertEquals(predicate.getUrlKeywords(), new HashSet<>());
+        assertEquals(predicate.getNotUrlKeywords(), new HashSet<>());
     }
 
     @Test
-    void withNameKeywords() {
+    void withoutNameKeywords_noDuplicateKeywords_success() {
+        BookmarkPredicate predicate = new BookmarkPredicate().withoutNameKeywords(KEYWORD_LIST_MULTIPLE);
+        assertEquals(predicate.getNameKeywords(), new HashSet<>());
+        assertEquals(predicate.getNotNameKeywords(), new HashSet<>(KEYWORD_LIST_MULTIPLE));
+        assertEquals(predicate.getUrlKeywords(), new HashSet<>());
+        assertEquals(predicate.getNotUrlKeywords(), new HashSet<>());
     }
 
     @Test
-    void withoutNameKeywords() {
+    void withUrlKeywords_noDuplicateKeywords_success() {
+        BookmarkPredicate predicate = new BookmarkPredicate().withUrlKeywords(KEYWORD_LIST_MULTIPLE);
+        assertEquals(predicate.getNameKeywords(), new HashSet<>());
+        assertEquals(predicate.getNotNameKeywords(), new HashSet<>());
+        assertEquals(predicate.getUrlKeywords(), new HashSet<>(KEYWORD_LIST_MULTIPLE));
+        assertEquals(predicate.getNotUrlKeywords(), new HashSet<>());
     }
 
     @Test
-    void withUrlKeywords() {
-    }
-
-    @Test
-    void withoutUrlKeywords() {
-    }
-
-    @Test
-    void testEquals() {
+    void withoutUrlKeywords_noDuplicateKeywords_success() {
+        BookmarkPredicate predicate = new BookmarkPredicate().withoutUrlKeywords(KEYWORD_LIST_MULTIPLE);
+        assertEquals(predicate.getNameKeywords(), new HashSet<>());
+        assertEquals(predicate.getNotNameKeywords(), new HashSet<>());
+        assertEquals(predicate.getUrlKeywords(), new HashSet<>());
+        assertEquals(predicate.getNotUrlKeywords(), new HashSet<>(KEYWORD_LIST_MULTIPLE));
     }
 }


### PR DESCRIPTION
Closes #40 

Completed:
* Refactor predicates so that they can be stored in and retrieved from Storage.
* Allow autotags to be deleted
* Write tests
* Add filters for `f/` `nf/`

To be done in another PR:
* Update tests
* Allow autotags to be edited
* Add filters for `t/` `nt/` (TBC - might be more complicated than initially thought)

_Note: There are a few random commits about URL validation because I accidentally rebased the wrong branch. But they don't change anything new!_