### PR TITLE
Implement find by folder/tag

### DIFF
--- a/src/main/java/seedu/mark/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/FindCommand.java
@@ -2,12 +2,10 @@ package seedu.mark.logic.commands;
 
 import static seedu.mark.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.function.Predicate;
-
 import seedu.mark.commons.core.Messages;
 import seedu.mark.logic.commands.results.CommandResult;
 import seedu.mark.model.Model;
-import seedu.mark.model.bookmark.Bookmark;
+import seedu.mark.model.predicates.BookmarkContainsKeywordsPredicate;
 import seedu.mark.storage.Storage;
 
 /**
@@ -23,9 +21,9 @@ public class FindCommand extends Command {
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " stack-overflow github programming";
 
-    private final Predicate<Bookmark> predicate;
+    private final BookmarkContainsKeywordsPredicate predicate;
 
-    public FindCommand(Predicate<Bookmark> predicate) {
+    public FindCommand(BookmarkContainsKeywordsPredicate predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/mark/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/FindCommand.java
@@ -2,10 +2,12 @@ package seedu.mark.logic.commands;
 
 import static seedu.mark.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.function.Predicate;
+
 import seedu.mark.commons.core.Messages;
 import seedu.mark.logic.commands.results.CommandResult;
 import seedu.mark.model.Model;
-import seedu.mark.model.predicates.IdentifiersContainKeywordsPredicate;
+import seedu.mark.model.bookmark.Bookmark;
 import seedu.mark.storage.Storage;
 
 /**
@@ -21,9 +23,9 @@ public class FindCommand extends Command {
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " stack-overflow github programming";
 
-    private final IdentifiersContainKeywordsPredicate predicate;
+    private final Predicate<Bookmark> predicate;
 
-    public FindCommand(IdentifiersContainKeywordsPredicate predicate) {
+    public FindCommand(Predicate<Bookmark> predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/mark/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/mark/logic/parser/FindCommandParser.java
@@ -1,12 +1,20 @@
 package seedu.mark.logic.parser;
 
 import static seedu.mark.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.mark.logic.parser.CliSyntax.PREFIX_FOLDER;
+import static seedu.mark.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.mark.model.Model.PREDICATE_SHOW_NO_BOOKMARKS;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
 
 import seedu.mark.logic.commands.FindCommand;
 import seedu.mark.logic.parser.exceptions.ParseException;
+import seedu.mark.model.bookmark.Bookmark;
+import seedu.mark.model.predicates.FolderContainsKeywordsPredicate;
 import seedu.mark.model.predicates.IdentifiersContainKeywordsPredicate;
+import seedu.mark.model.predicates.TagContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -20,14 +28,33 @@ public class FindCommandParser implements Parser<FindCommand> {
      */
     public FindCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_TAG, PREFIX_FOLDER);
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String[] nameKeywords = trimmedArgs.split("\\s+");
-
-        return new FindCommand(new IdentifiersContainKeywordsPredicate(Arrays.asList(nameKeywords)));
+        Predicate<Bookmark> predicate = PREDICATE_SHOW_NO_BOOKMARKS;
+        List<String> tagKeywords = argMultimap.getAllValues(PREFIX_TAG);
+        List<String> folderKeywords = argMultimap.getAllValues(PREFIX_FOLDER);
+        String preamble = argMultimap.getPreamble();
+        tagKeywords.removeIf(String::isEmpty);
+        folderKeywords.removeIf(String::isEmpty);
+        if (tagKeywords.isEmpty() && folderKeywords.isEmpty() && preamble.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+        if (!tagKeywords.isEmpty()) {
+            predicate = predicate.or(new TagContainsKeywordsPredicate(tagKeywords));
+        }
+        if (!folderKeywords.isEmpty()) {
+            predicate = predicate.or(new FolderContainsKeywordsPredicate(folderKeywords));
+        }
+        if (!preamble.isEmpty()) {
+            String[] nameKeywords = preamble.split("\\s+");
+            predicate = predicate.or(new IdentifiersContainKeywordsPredicate(Arrays.asList(nameKeywords)));
+        }
+        return new FindCommand(predicate);
     }
 
 }

--- a/src/main/java/seedu/mark/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/mark/logic/parser/FindCommandParser.java
@@ -32,17 +32,15 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
 
         String preamble = argMultimap.getPreamble();
-        List<String> nameKeywords = new LinkedList<>(Arrays.asList(preamble.split("\\s+")));
+        List<String> identifierKeywords = new LinkedList<>(Arrays.asList(preamble.split("\\s+")));
         List<String> tagKeywords = argMultimap.getAllValues(PREFIX_TAG);
         List<String> folderKeywords = argMultimap.getAllValues(PREFIX_FOLDER);
-        nameKeywords.removeIf(String::isEmpty);
+        identifierKeywords.removeIf(String::isEmpty);
         tagKeywords.removeIf(String::isEmpty);
         folderKeywords.removeIf(String::isEmpty);
 
-        BookmarkContainsKeywordsPredicate predicate = new BookmarkContainsKeywordsPredicate();
-        predicate.setIdentifierPredicate(nameKeywords);
-        predicate.setTagPredicate(tagKeywords);
-        predicate.setFolderPredicate(folderKeywords);
+        BookmarkContainsKeywordsPredicate predicate = new BookmarkContainsKeywordsPredicate(identifierKeywords,
+                tagKeywords, folderKeywords);
 
         if (!predicate.isAnyPredicatePresent()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/mark/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/mark/logic/parser/FindCommandParser.java
@@ -3,18 +3,14 @@ package seedu.mark.logic.parser;
 import static seedu.mark.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.mark.logic.parser.CliSyntax.PREFIX_FOLDER;
 import static seedu.mark.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.mark.model.Model.PREDICATE_SHOW_NO_BOOKMARKS;
 
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
-import java.util.function.Predicate;
 
 import seedu.mark.logic.commands.FindCommand;
 import seedu.mark.logic.parser.exceptions.ParseException;
-import seedu.mark.model.bookmark.Bookmark;
-import seedu.mark.model.predicates.FolderContainsKeywordsPredicate;
-import seedu.mark.model.predicates.IdentifiersContainKeywordsPredicate;
-import seedu.mark.model.predicates.TagContainsKeywordsPredicate;
+import seedu.mark.model.predicates.BookmarkContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -35,26 +31,23 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        Predicate<Bookmark> predicate = PREDICATE_SHOW_NO_BOOKMARKS;
+        String preamble = argMultimap.getPreamble();
+        List<String> nameKeywords = new LinkedList<>(Arrays.asList(preamble.split("\\s+")));
         List<String> tagKeywords = argMultimap.getAllValues(PREFIX_TAG);
         List<String> folderKeywords = argMultimap.getAllValues(PREFIX_FOLDER);
-        String preamble = argMultimap.getPreamble();
+        nameKeywords.removeIf(String::isEmpty);
         tagKeywords.removeIf(String::isEmpty);
         folderKeywords.removeIf(String::isEmpty);
-        if (tagKeywords.isEmpty() && folderKeywords.isEmpty() && preamble.isEmpty()) {
+
+        BookmarkContainsKeywordsPredicate predicate = new BookmarkContainsKeywordsPredicate();
+        predicate.setIdentifierPredicate(nameKeywords);
+        predicate.setTagPredicate(tagKeywords);
+        predicate.setFolderPredicate(folderKeywords);
+
+        if (!predicate.isAnyPredicatePresent()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
-        if (!tagKeywords.isEmpty()) {
-            predicate = predicate.or(new TagContainsKeywordsPredicate(tagKeywords));
-        }
-        if (!folderKeywords.isEmpty()) {
-            predicate = predicate.or(new FolderContainsKeywordsPredicate(folderKeywords));
-        }
-        if (!preamble.isEmpty()) {
-            String[] nameKeywords = preamble.split("\\s+");
-            predicate = predicate.or(new IdentifiersContainKeywordsPredicate(Arrays.asList(nameKeywords)));
-        }
+
         return new FindCommand(predicate);
     }
-
 }

--- a/src/main/java/seedu/mark/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/mark/logic/parser/FindCommandParser.java
@@ -35,6 +35,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         List<String> identifierKeywords = new LinkedList<>(Arrays.asList(preamble.split("\\s+")));
         List<String> tagKeywords = argMultimap.getAllValues(PREFIX_TAG);
         List<String> folderKeywords = argMultimap.getAllValues(PREFIX_FOLDER);
+        // Remove keyword empty string
         identifierKeywords.removeIf(String::isEmpty);
         tagKeywords.removeIf(String::isEmpty);
         folderKeywords.removeIf(String::isEmpty);
@@ -42,7 +43,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         BookmarkContainsKeywordsPredicate predicate = new BookmarkContainsKeywordsPredicate(identifierKeywords,
                 tagKeywords, folderKeywords);
 
-        if (!predicate.isAnyPredicatePresent()) {
+        if (!predicate.isAnyKeywordPresent()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 

--- a/src/main/java/seedu/mark/model/Model.java
+++ b/src/main/java/seedu/mark/model/Model.java
@@ -23,6 +23,9 @@ public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Bookmark> PREDICATE_SHOW_ALL_BOOKMARKS = unused -> true;
 
+    /** {@code Predicate} that always evaluate to false */
+    Predicate<Bookmark> PREDICATE_SHOW_NO_BOOKMARKS = unused -> false;
+
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
      */

--- a/src/main/java/seedu/mark/model/predicates/BookmarkContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/mark/model/predicates/BookmarkContainsKeywordsPredicate.java
@@ -1,0 +1,87 @@
+package seedu.mark.model.predicates;
+
+import static seedu.mark.model.Model.PREDICATE_SHOW_NO_BOOKMARKS;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import seedu.mark.commons.util.CollectionUtil;
+import seedu.mark.model.bookmark.Bookmark;
+
+/**
+ * Tests that part of a {@code Bookmark}'s data fields (except remark) matches any of the keywords given.
+ */
+public class BookmarkContainsKeywordsPredicate implements Predicate<Bookmark> {
+    private IdentifiersContainKeywordsPredicate identifierPredicate;
+    private TagContainsKeywordsPredicate tagPredicate;
+    private FolderContainsKeywordsPredicate folderPredicate;
+    private Predicate<Bookmark> predicate = PREDICATE_SHOW_NO_BOOKMARKS;
+
+    public Optional<Predicate<Bookmark>> getIdentifierPredicate() {
+        return Optional.ofNullable(identifierPredicate);
+    }
+
+    public Optional<Predicate<Bookmark>> getTagPredicate() {
+        return Optional.ofNullable(tagPredicate);
+    }
+
+    public Optional<Predicate<Bookmark>> getFolderPredicate() {
+        return Optional.ofNullable(folderPredicate);
+    }
+
+    public void setIdentifierPredicate(List<String> keywords) {
+        if (keywords.isEmpty()) {
+            identifierPredicate = null;
+        } else {
+            identifierPredicate = new IdentifiersContainKeywordsPredicate(keywords);
+        }
+    }
+
+    public void setTagPredicate(List<String> keywords) {
+        if (keywords.isEmpty()) {
+            tagPredicate = null;
+        } else {
+            tagPredicate = new TagContainsKeywordsPredicate(keywords);
+        }
+    }
+
+    public void setFolderPredicate(List<String> keywords) {
+        if (keywords.isEmpty()) {
+            folderPredicate = null;
+        } else {
+            folderPredicate = new FolderContainsKeywordsPredicate(keywords);
+        }
+    }
+
+    /**
+     * Prepares the predicate for test
+     */
+    public void preparePredicate() {
+        predicate = predicate.or(getIdentifierPredicate().orElse(PREDICATE_SHOW_NO_BOOKMARKS));
+        predicate = predicate.or(getTagPredicate().orElse(PREDICATE_SHOW_NO_BOOKMARKS));
+        predicate = predicate.or(getFolderPredicate().orElse(PREDICATE_SHOW_NO_BOOKMARKS));
+    }
+
+    /**
+     * Returns true if at least one predicate is present.
+     */
+    public boolean isAnyPredicatePresent() {
+        return CollectionUtil.isAnyNonNull(identifierPredicate, tagPredicate, folderPredicate);
+    }
+
+    @Override
+    public boolean test(Bookmark bookmark) {
+        preparePredicate();
+        return predicate.test(bookmark);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof BookmarkContainsKeywordsPredicate // instanceof handles nulls
+                && getIdentifierPredicate().equals(((BookmarkContainsKeywordsPredicate) other).getIdentifierPredicate())
+                && getTagPredicate().equals(((BookmarkContainsKeywordsPredicate) other).getTagPredicate())
+                && getFolderPredicate().equals(((BookmarkContainsKeywordsPredicate) other).getFolderPredicate()));
+    }
+}

--- a/src/main/java/seedu/mark/model/predicates/BookmarkContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/mark/model/predicates/BookmarkContainsKeywordsPredicate.java
@@ -1,12 +1,11 @@
 package seedu.mark.model.predicates;
 
+import static seedu.mark.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.mark.model.Model.PREDICATE_SHOW_NO_BOOKMARKS;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Predicate;
 
-import seedu.mark.commons.util.CollectionUtil;
 import seedu.mark.model.bookmark.Bookmark;
 
 /**
@@ -15,82 +14,45 @@ import seedu.mark.model.bookmark.Bookmark;
 public class BookmarkContainsKeywordsPredicate implements Predicate<Bookmark> {
     private static final Predicate<Bookmark> DEFAULT_PREDICATE = PREDICATE_SHOW_NO_BOOKMARKS;
 
-    private IdentifiersContainKeywordsPredicate identifierPredicate;
-    private TagContainsKeywordsPredicate tagPredicate;
-    private FolderContainsKeywordsPredicate folderPredicate;
-
-    public BookmarkContainsKeywordsPredicate() {}
+    private List<String> identifierKeywords;
+    private List<String> tagKeywords;
+    private List<String> folderKeywords;
 
     public BookmarkContainsKeywordsPredicate(List<String> identifierKeywords, List<String> tagKeywords,
                                              List<String> folderKeywords) {
-        setIdentifierPredicate(identifierKeywords);
-        setTagPredicate(tagKeywords);
-        setFolderPredicate(folderKeywords);
-    }
-
-    public Optional<Predicate<Bookmark>> getIdentifierPredicate() {
-        return Optional.ofNullable(identifierPredicate);
-    }
-
-    public Optional<Predicate<Bookmark>> getTagPredicate() {
-        return Optional.ofNullable(tagPredicate);
-    }
-
-    public Optional<Predicate<Bookmark>> getFolderPredicate() {
-        return Optional.ofNullable(folderPredicate);
-    }
-
-    public void setIdentifierPredicate(List<String> keywords) {
-        if (keywords.isEmpty()) {
-            identifierPredicate = null;
-        } else {
-            identifierPredicate = new IdentifiersContainKeywordsPredicate(keywords);
-        }
-    }
-
-    public void setTagPredicate(List<String> keywords) {
-        if (keywords.isEmpty()) {
-            tagPredicate = null;
-        } else {
-            tagPredicate = new TagContainsKeywordsPredicate(keywords);
-        }
-    }
-
-    public void setFolderPredicate(List<String> keywords) {
-        if (keywords.isEmpty()) {
-            folderPredicate = null;
-        } else {
-            folderPredicate = new FolderContainsKeywordsPredicate(keywords);
-        }
+        requireAllNonNull(identifierKeywords, tagKeywords, folderKeywords);
+        this.identifierKeywords = identifierKeywords;
+        this.tagKeywords = tagKeywords;
+        this.folderKeywords = folderKeywords;
     }
 
     /**
      * Prepares the predicate for test
      */
-    public Predicate<Bookmark> preparePredicate() {
-        return DEFAULT_PREDICATE.or(getIdentifierPredicate().orElse(DEFAULT_PREDICATE))
-                .or(getTagPredicate().orElse(DEFAULT_PREDICATE))
-                .or(getFolderPredicate().orElse(DEFAULT_PREDICATE));
+    public Predicate<Bookmark> getPredicate() {
+        return DEFAULT_PREDICATE.or(new IdentifiersContainKeywordsPredicate(identifierKeywords))
+                .or(new TagContainsKeywordsPredicate(tagKeywords))
+                .or(new FolderContainsKeywordsPredicate(folderKeywords));
     }
 
     /**
-     * Returns true if at least one predicate is present.
+     * Returns true if at least one keyword is present.
      */
-    public boolean isAnyPredicatePresent() {
-        return CollectionUtil.isAnyNonNull(identifierPredicate, tagPredicate, folderPredicate);
+    public boolean isAnyKeywordPresent() {
+        return !(identifierKeywords.isEmpty() && tagKeywords.isEmpty() && folderKeywords.isEmpty());
     }
 
     @Override
     public boolean test(Bookmark bookmark) {
-        return preparePredicate().test(bookmark);
+        return getPredicate().test(bookmark);
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof BookmarkContainsKeywordsPredicate // instanceof handles nulls
-                && getIdentifierPredicate().equals(((BookmarkContainsKeywordsPredicate) other).getIdentifierPredicate())
-                && getTagPredicate().equals(((BookmarkContainsKeywordsPredicate) other).getTagPredicate())
-                && getFolderPredicate().equals(((BookmarkContainsKeywordsPredicate) other).getFolderPredicate()));
+                && identifierKeywords.equals(((BookmarkContainsKeywordsPredicate) other).identifierKeywords)
+                && tagKeywords.equals(((BookmarkContainsKeywordsPredicate) other).tagKeywords)
+                && folderKeywords.equals(((BookmarkContainsKeywordsPredicate) other).folderKeywords));
     }
 }

--- a/src/main/java/seedu/mark/model/predicates/BookmarkContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/mark/model/predicates/BookmarkContainsKeywordsPredicate.java
@@ -13,10 +13,20 @@ import seedu.mark.model.bookmark.Bookmark;
  * Tests that part of a {@code Bookmark}'s data fields (except remark) matches any of the keywords given.
  */
 public class BookmarkContainsKeywordsPredicate implements Predicate<Bookmark> {
+    private static final Predicate<Bookmark> DEFAULT_PREDICATE = PREDICATE_SHOW_NO_BOOKMARKS;
+
     private IdentifiersContainKeywordsPredicate identifierPredicate;
     private TagContainsKeywordsPredicate tagPredicate;
     private FolderContainsKeywordsPredicate folderPredicate;
-    private Predicate<Bookmark> predicate = PREDICATE_SHOW_NO_BOOKMARKS;
+
+    public BookmarkContainsKeywordsPredicate() {}
+
+    public BookmarkContainsKeywordsPredicate(List<String> identifierKeywords, List<String> tagKeywords,
+                                             List<String> folderKeywords) {
+        setIdentifierPredicate(identifierKeywords);
+        setTagPredicate(tagKeywords);
+        setFolderPredicate(folderKeywords);
+    }
 
     public Optional<Predicate<Bookmark>> getIdentifierPredicate() {
         return Optional.ofNullable(identifierPredicate);
@@ -57,10 +67,10 @@ public class BookmarkContainsKeywordsPredicate implements Predicate<Bookmark> {
     /**
      * Prepares the predicate for test
      */
-    public void preparePredicate() {
-        predicate = predicate.or(getIdentifierPredicate().orElse(PREDICATE_SHOW_NO_BOOKMARKS));
-        predicate = predicate.or(getTagPredicate().orElse(PREDICATE_SHOW_NO_BOOKMARKS));
-        predicate = predicate.or(getFolderPredicate().orElse(PREDICATE_SHOW_NO_BOOKMARKS));
+    public Predicate<Bookmark> preparePredicate() {
+        return DEFAULT_PREDICATE.or(getIdentifierPredicate().orElse(DEFAULT_PREDICATE))
+                .or(getTagPredicate().orElse(DEFAULT_PREDICATE))
+                .or(getFolderPredicate().orElse(DEFAULT_PREDICATE));
     }
 
     /**
@@ -72,8 +82,7 @@ public class BookmarkContainsKeywordsPredicate implements Predicate<Bookmark> {
 
     @Override
     public boolean test(Bookmark bookmark) {
-        preparePredicate();
-        return predicate.test(bookmark);
+        return preparePredicate().test(bookmark);
     }
 
     @Override

--- a/src/main/java/seedu/mark/model/predicates/FolderContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/mark/model/predicates/FolderContainsKeywordsPredicate.java
@@ -3,7 +3,6 @@ package seedu.mark.model.predicates;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.mark.commons.util.StringUtil;
 import seedu.mark.model.bookmark.Bookmark;
 
 /**
@@ -19,7 +18,7 @@ public class FolderContainsKeywordsPredicate implements Predicate<Bookmark> {
     @Override
     public boolean test(Bookmark bookmark) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsPhraseIgnoreCase(bookmark.getFolder().folderName, keyword));
+                .anyMatch(keyword -> bookmark.getFolder().folderName.equals(keyword));
     }
 
     @Override

--- a/src/main/java/seedu/mark/model/predicates/FolderContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/mark/model/predicates/FolderContainsKeywordsPredicate.java
@@ -1,0 +1,32 @@
+package seedu.mark.model.predicates;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.mark.commons.util.StringUtil;
+import seedu.mark.model.bookmark.Bookmark;
+
+/**
+ * Tests that part of a {@code Bookmark}'s {@code Folder} matches any of the keywords given.
+ */
+public class FolderContainsKeywordsPredicate implements Predicate<Bookmark> {
+    private final List<String> keywords;
+
+    public FolderContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Bookmark bookmark) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsPhraseIgnoreCase(bookmark.getFolder().folderName, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FolderContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((FolderContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/mark/model/predicates/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/mark/model/predicates/TagContainsKeywordsPredicate.java
@@ -3,7 +3,6 @@ package seedu.mark.model.predicates;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.mark.commons.util.StringUtil;
 import seedu.mark.model.bookmark.Bookmark;
 
 /**
@@ -20,7 +19,7 @@ public class TagContainsKeywordsPredicate implements Predicate<Bookmark> {
     public boolean test(Bookmark bookmark) {
         return keywords.stream()
                 .anyMatch(keyword -> bookmark.getTags()
-                        .stream().anyMatch(tag -> StringUtil.containsPhraseIgnoreCase(tag.tagName, keyword)));
+                        .stream().anyMatch(tag -> tag.tagName.equals(keyword)));
     }
 
     @Override

--- a/src/main/java/seedu/mark/model/predicates/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/mark/model/predicates/TagContainsKeywordsPredicate.java
@@ -1,0 +1,33 @@
+package seedu.mark.model.predicates;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.mark.commons.util.StringUtil;
+import seedu.mark.model.bookmark.Bookmark;
+
+/**
+ * Tests that part of a {@code Bookmark}'s {@code Tag} matches any of the keywords given.
+ */
+public class TagContainsKeywordsPredicate implements Predicate<Bookmark> {
+    private final List<String> keywords;
+
+    public TagContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Bookmark bookmark) {
+        return keywords.stream()
+                .anyMatch(keyword -> bookmark.getTags()
+                        .stream().anyMatch(tag -> StringUtil.containsPhraseIgnoreCase(tag.tagName, keyword)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TagContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((TagContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/test/java/seedu/mark/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/FindCommandTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import seedu.mark.model.Model;
 import seedu.mark.model.ModelManager;
 import seedu.mark.model.UserPrefs;
-import seedu.mark.model.predicates.IdentifiersContainKeywordsPredicate;
+import seedu.mark.model.predicates.BookmarkContainsKeywordsPredicate;
 import seedu.mark.storage.StorageStub;
 
 /**
@@ -30,10 +30,10 @@ public class FindCommandTest {
 
     @Test
     public void equals() {
-        IdentifiersContainKeywordsPredicate firstPredicate =
-                new IdentifiersContainKeywordsPredicate(Collections.singletonList("first"));
-        IdentifiersContainKeywordsPredicate secondPredicate =
-                new IdentifiersContainKeywordsPredicate(Collections.singletonList("second"));
+        BookmarkContainsKeywordsPredicate firstPredicate = new BookmarkContainsKeywordsPredicate();
+        firstPredicate.setIdentifierPredicate(Collections.singletonList("first"));
+        BookmarkContainsKeywordsPredicate secondPredicate = new BookmarkContainsKeywordsPredicate();
+        secondPredicate.setIdentifierPredicate(Collections.singletonList("second"));
 
         FindCommand findFirstCommand = new FindCommand(firstPredicate);
         FindCommand findSecondCommand = new FindCommand(secondPredicate);
@@ -58,7 +58,7 @@ public class FindCommandTest {
     @Test
     public void execute_zeroKeywords_noBookmarkFound() {
         String expectedMessage = String.format(MESSAGE_BOOKMARKS_LISTED_OVERVIEW, 0);
-        IdentifiersContainKeywordsPredicate predicate = preparePredicate(" ");
+        BookmarkContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredBookmarkList(predicate);
         assertCommandSuccess(command, model, new StorageStub(), expectedMessage, expectedModel);
@@ -68,7 +68,7 @@ public class FindCommandTest {
     @Test
     public void execute_multipleKeywords_multipleBookmarksFound() {
         String expectedMessage = String.format(MESSAGE_BOOKMARKS_LISTED_OVERVIEW, 3);
-        IdentifiersContainKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
+        BookmarkContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredBookmarkList(predicate);
         assertCommandSuccess(command, model, new StorageStub(), expectedMessage, expectedModel);
@@ -78,7 +78,9 @@ public class FindCommandTest {
     /**
      * Parses {@code userInput} into a {@code IdentifiersContainKeywordsPredicate}.
      */
-    private IdentifiersContainKeywordsPredicate preparePredicate(String userInput) {
-        return new IdentifiersContainKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    private BookmarkContainsKeywordsPredicate preparePredicate(String userInput) {
+        BookmarkContainsKeywordsPredicate predicate = new BookmarkContainsKeywordsPredicate();
+        predicate.setIdentifierPredicate(Arrays.asList(userInput.split("\\s+")));
+        return predicate;
     }
 }

--- a/src/test/java/seedu/mark/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/FindCommandTest.java
@@ -76,7 +76,7 @@ public class FindCommandTest {
     }
 
     /**
-     * Parses {@code userInput} into a {@code IdentifiersContainKeywordsPredicate}.
+     * Parses {@code userInput} into a {@code BookmarkContainKeywordsPredicate}.
      */
     private BookmarkContainsKeywordsPredicate preparePredicate(String userInput) {
         BookmarkContainsKeywordsPredicate predicate = new BookmarkContainsKeywordsPredicate();

--- a/src/test/java/seedu/mark/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/FindCommandTest.java
@@ -30,10 +30,10 @@ public class FindCommandTest {
 
     @Test
     public void equals() {
-        BookmarkContainsKeywordsPredicate firstPredicate = new BookmarkContainsKeywordsPredicate();
-        firstPredicate.setIdentifierPredicate(Collections.singletonList("first"));
-        BookmarkContainsKeywordsPredicate secondPredicate = new BookmarkContainsKeywordsPredicate();
-        secondPredicate.setIdentifierPredicate(Collections.singletonList("second"));
+        BookmarkContainsKeywordsPredicate firstPredicate = new BookmarkContainsKeywordsPredicate(
+                Collections.singletonList("first"), Collections.emptyList(), Collections.emptyList());
+        BookmarkContainsKeywordsPredicate secondPredicate = new BookmarkContainsKeywordsPredicate(
+                Collections.singletonList("second"), Collections.emptyList(), Collections.emptyList());
 
         FindCommand findFirstCommand = new FindCommand(firstPredicate);
         FindCommand findSecondCommand = new FindCommand(secondPredicate);
@@ -79,8 +79,7 @@ public class FindCommandTest {
      * Parses {@code userInput} into a {@code BookmarkContainKeywordsPredicate}.
      */
     private BookmarkContainsKeywordsPredicate preparePredicate(String userInput) {
-        BookmarkContainsKeywordsPredicate predicate = new BookmarkContainsKeywordsPredicate();
-        predicate.setIdentifierPredicate(Arrays.asList(userInput.split("\\s+")));
-        return predicate;
+        return new BookmarkContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")),
+                Collections.emptyList(), Collections.emptyList());
     }
 }

--- a/src/test/java/seedu/mark/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/FindCommandParserTest.java
@@ -5,6 +5,7 @@ import static seedu.mark.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.mark.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,8 +23,8 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsFindCommand() {
-        BookmarkContainsKeywordsPredicate predicate = new BookmarkContainsKeywordsPredicate();
-        predicate.setIdentifierPredicate(Arrays.asList("coding", "algorithm"));
+        BookmarkContainsKeywordsPredicate predicate = new BookmarkContainsKeywordsPredicate(
+                Arrays.asList("coding", "algorithm"), Collections.emptyList(), Collections.emptyList());
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand = new FindCommand(predicate);
         assertParseSuccess(parser, "coding algorithm", expectedFindCommand);

--- a/src/test/java/seedu/mark/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/FindCommandParserTest.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.mark.logic.commands.FindCommand;
-import seedu.mark.model.predicates.IdentifiersContainKeywordsPredicate;
+import seedu.mark.model.predicates.BookmarkContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
 
@@ -22,9 +22,10 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_validArgs_returnsFindCommand() {
+        BookmarkContainsKeywordsPredicate predicate = new BookmarkContainsKeywordsPredicate();
+        predicate.setIdentifierPredicate(Arrays.asList("coding", "algorithm"));
         // no leading and trailing whitespaces
-        FindCommand expectedFindCommand =
-                new FindCommand(new IdentifiersContainKeywordsPredicate(Arrays.asList("coding", "algorithm")));
+        FindCommand expectedFindCommand = new FindCommand(predicate);
         assertParseSuccess(parser, "coding algorithm", expectedFindCommand);
 
         // multiple whitespaces between keywords

--- a/src/test/java/seedu/mark/logic/parser/MarkParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/MarkParserTest.java
@@ -13,6 +13,7 @@ import static seedu.mark.testutil.TypicalIndexes.INDEX_FIRST_BOOKMARK;
 
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -143,8 +144,8 @@ public class MarkParserTest {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        BookmarkContainsKeywordsPredicate predicate = new BookmarkContainsKeywordsPredicate();
-        predicate.setIdentifierPredicate(keywords);
+        BookmarkContainsKeywordsPredicate predicate = new BookmarkContainsKeywordsPredicate(
+                keywords, Collections.emptyList(), Collections.emptyList());
         assertEquals(new FindCommand(predicate), command);
     }
 

--- a/src/test/java/seedu/mark/logic/parser/MarkParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/MarkParserTest.java
@@ -39,7 +39,7 @@ import seedu.mark.model.autotag.SelectiveBookmarkTagger;
 import seedu.mark.model.bookmark.Bookmark;
 import seedu.mark.model.bookmark.Folder;
 import seedu.mark.model.bookmark.util.BookmarkBuilder;
-import seedu.mark.model.predicates.IdentifiersContainKeywordsPredicate;
+import seedu.mark.model.predicates.BookmarkContainsKeywordsPredicate;
 import seedu.mark.model.predicates.NameContainsKeywordsPredicate;
 import seedu.mark.model.tag.Tag;
 import seedu.mark.testutil.BookmarkUtil;
@@ -143,7 +143,9 @@ public class MarkParserTest {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new IdentifiersContainKeywordsPredicate(keywords)), command);
+        BookmarkContainsKeywordsPredicate predicate = new BookmarkContainsKeywordsPredicate();
+        predicate.setIdentifierPredicate(keywords);
+        assertEquals(new FindCommand(predicate), command);
     }
 
     @Test
@@ -174,7 +176,7 @@ public class MarkParserTest {
     public void parseCommand_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), () ->
-                parser.parseCommand(""));
+                        parser.parseCommand(""));
     }
 
     @Test


### PR DESCRIPTION
`BookmarkContainsKeywordPredicate` is kind of similar to `BookmarkPredicate` in #141. Might be a bit repetitive. The only difference is that `BookmarkContainsKeywordPredicate` is an OR relationship but `BookmarkPredicate` is AND (all the keywords must matched). 

For find by folder, only bookmarks that match the folder name will be displayed for now.
Ideally, it should display all the bookmarks under the specified folder and the subfolders. However, currently our Folder class does not contain any information about the parent folder.

(in another pr)
- Add tests