### PR TITLE
Refine import command

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -343,15 +343,17 @@ Exports all bookmarks tagged with `favorite` to a file named
 
 === Importing bookmarks: *`import`*
 
-Imports bookmarks from files on the hard disk.
+Imports bookmarks from files on the hard disk. A bookmark is, by default, imported
+into a folder with the same name as its original folder (even if the folder
+structure is different). If no such folder is found, the bookmark will be imported
+into the folder `ImportedBookmarks`.
 
-Format: `*import* FILENAME [MORE_FILENAMES]...`
+Format: `*import* FILENAME`
 
 ****
-* `FILENAME` should not include the file extension. E.g. `myBookmarks` and not
-`myBookmarks.json`
-* `FILENAME` is case sensitive.
-* `FILENAME` should be a file stored in the folder
+* `FILENAME` is case sensitive and should not include the file extension. E.g.
+`myBookmarks` and not `myBookmarks.json`
+* `FILENAME.json` should be a file stored in the folder
 `[applicationHome]/data/bookmarks/`.
 * The file corresponding to `FILENAME` should have a valid format, identical
 to the JSON files produced by `*export*`.
@@ -362,10 +364,6 @@ Examples:
 * `*import* myBookmarks` +
 Assuming `mark.jar` is stored in the folder `mark`, imports bookmarks from the
 file `mark/data/bookmarks/myBookmarks.json`
-
-* `*import* myBookmarks nusBookmarks youtubeBookmarks` +
-Imports bookmarks from the files `myBookmarks.json`, `nusBookmarks.json`,
-and `youtubeBookmarks.json`.
 
 === Creating an automatic tag: *`autotag`*
 

--- a/src/main/java/seedu/mark/model/Model.java
+++ b/src/main/java/seedu/mark/model/Model.java
@@ -13,7 +13,6 @@ import seedu.mark.model.autotag.SelectiveBookmarkTagger;
 import seedu.mark.model.bookmark.Bookmark;
 import seedu.mark.model.bookmark.Folder;
 import seedu.mark.model.bookmark.Url;
-import seedu.mark.model.folderstructure.FolderStructure;
 import seedu.mark.model.reminder.Reminder;
 
 /**

--- a/src/main/java/seedu/mark/model/Model.java
+++ b/src/main/java/seedu/mark/model/Model.java
@@ -114,12 +114,6 @@ public interface Model {
     boolean hasFolder(Folder folder);
 
     /**
-     * Attempts to add a structure of folders to Mark.
-     * Implementation to be decided.
-     */
-    void addFolders(FolderStructure foldersToAdd);
-
-    /**
      * Checks whether Mark contains this {@code tagger}.
      */
     boolean hasTagger(SelectiveBookmarkTagger tagger);

--- a/src/main/java/seedu/mark/model/ModelManager.java
+++ b/src/main/java/seedu/mark/model/ModelManager.java
@@ -23,7 +23,6 @@ import seedu.mark.model.autotag.SelectiveBookmarkTagger;
 import seedu.mark.model.bookmark.Bookmark;
 import seedu.mark.model.bookmark.Folder;
 import seedu.mark.model.bookmark.Url;
-import seedu.mark.model.folderstructure.FolderStructure;
 import seedu.mark.model.reminder.Reminder;
 
 /**
@@ -157,26 +156,6 @@ public class ModelManager implements Model {
     @Override
     public boolean hasFolder(Folder folder) {
         return versionedMark.hasFolder(folder);
-    }
-
-    @Override
-    public void addFolders(FolderStructure foldersToAdd) {
-        requireNonNull(foldersToAdd);
-        // TODO: decide what to do here
-
-        // option 1:
-        // get ROOT
-        // add subfolders of imported folder structure to ROOT
-        // check for duplicate folders and ignore them
-        // if folder is found, then ignore
-        // for each Bookmark in list, if name = duplicate-folder, change folder to ROOT
-
-        // option 2:
-        // get ROOT
-        // create a new subfolder for imported bookmarks (de-conflict names if necessary)
-        // import each folder into import-folder
-        // check for duplicate folders and rename if necessary (e.g. folder-1)
-        // for each Bookmark in list, if name = renamed-folder, change name to new-name
     }
 
     @Override

--- a/src/main/java/seedu/mark/model/bookmark/Folder.java
+++ b/src/main/java/seedu/mark/model/bookmark/Folder.java
@@ -12,8 +12,10 @@ public class Folder {
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     private static final String ROOT_FOLDER_NAME = "ROOT";
+    private static final String IMPORT_FOLDER_NAME = "ImportedBookmarks";
     public static final String DEFAULT_FOLDER_NAME = ROOT_FOLDER_NAME;
     public static final Folder ROOT_FOLDER = new Folder(ROOT_FOLDER_NAME);
+    public static final Folder IMPORT_FOLDER = new Folder(IMPORT_FOLDER_NAME);
 
     public final String folderName;
 

--- a/src/test/java/seedu/mark/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/ImportCommandTest.java
@@ -62,7 +62,7 @@ public class ImportCommandTest {
      */
     private static List<Bookmark> setToRootFolder(List<Bookmark> bookmarks) {
         return bookmarks.stream()
-                .map(ImportCommand.MarkImporter::setToRootFolder)
+                .map(ImportCommand.MarkImporter::setFolderAsImportFolder)
                 .collect(Collectors.toList());
     }
 

--- a/src/test/java/seedu/mark/logic/commands/ImportCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/ImportCommandTest.java
@@ -60,7 +60,7 @@ public class ImportCommandTest {
     /**
      * Sets the {@code Folder} of all bookmarks in the given list to the root folder.
      */
-    private static List<Bookmark> setToRootFolder(List<Bookmark> bookmarks) {
+    private static List<Bookmark> setFolderAsImportFolder(List<Bookmark> bookmarks) {
         return bookmarks.stream()
                 .map(ImportCommand.MarkImporter::setFolderAsImportFolder)
                 .collect(Collectors.toList());
@@ -96,7 +96,7 @@ public class ImportCommandTest {
         // set up expected model with appropriate state
         Model expectedModel = new ModelManager(new Mark(), new UserPrefs());
         Mark expectedMark = new Mark();
-        expectedMark.setBookmarks(setToRootFolder(getTypicalBookmarks())); // strip folders
+        expectedMark.setBookmarks(setFolderAsImportFolder(getTypicalBookmarks())); // strip folders
         expectedModel.setMark(expectedMark);
         expectedModel.saveMark(expectedMessage);
 
@@ -134,7 +134,7 @@ public class ImportCommandTest {
         ImportCommand command = new ImportCommand(filePath);
 
         // initial model: 3 bookmarks in root folder
-        List<Bookmark> existingBookmarks = setToRootFolder(Arrays.asList(ALICE, BENSON, CARL));
+        List<Bookmark> existingBookmarks = setFolderAsImportFolder(Arrays.asList(ALICE, BENSON, CARL));
         Mark markWithSomeBookmarks = new Mark();
         existingBookmarks.forEach(markWithSomeBookmarks::addBookmark);
         Model initialModel = new ModelManager(markWithSomeBookmarks, new UserPrefs());
@@ -146,7 +146,7 @@ public class ImportCommandTest {
         // expected model: 7 bookmarks in root folder (4 imported)
         Model expectedModel = new ModelManager(markWithSomeBookmarks, new UserPrefs());
         Mark expectedMark = new Mark();
-        expectedMark.setBookmarks(setToRootFolder(getTypicalBookmarks()));
+        expectedMark.setBookmarks(setFolderAsImportFolder(getTypicalBookmarks()));
         expectedModel.setMark(expectedMark);
         expectedModel.saveMark(expectedMessage);
 
@@ -220,7 +220,7 @@ public class ImportCommandTest {
                 return Optional.of(getTypicalMark());
             } else if (filePath.equals(PATH_NO_FOLDER_FILE)) {
                 Mark mark = new Mark();
-                mark.setBookmarks(setToRootFolder(getTypicalBookmarks()));
+                mark.setBookmarks(setFolderAsImportFolder(getTypicalBookmarks()));
                 return Optional.of(mark);
             } else if (filePath.equals(PATH_NO_BOOKMARK_FILE)) {
                 Mark mark = new Mark();

--- a/src/test/java/seedu/mark/logic/commands/MarkImporterTest.java
+++ b/src/test/java/seedu/mark/logic/commands/MarkImporterTest.java
@@ -2,8 +2,12 @@ package seedu.mark.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.mark.testutil.TypicalBookmarks.ALICE;
+import static seedu.mark.testutil.TypicalBookmarks.BENSON;
 import static seedu.mark.testutil.TypicalBookmarks.getTypicalBookmarks;
 import static seedu.mark.testutil.TypicalBookmarks.getTypicalMark;
+
+import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
@@ -35,8 +39,16 @@ public class MarkImporterTest {
         assertFalse(markImporter.equals(5));
 
         // different model -> returns false
-        Model differentModel = new ModelManager(getTypicalMark(), new UserPrefs());
-        assertFalse(markImporter.equals(new MarkImporter(differentModel, mark)));
+        Model typicalMarkModel = new ModelManager(getTypicalMark(), new UserPrefs());
+        assertFalse(markImporter.equals(new MarkImporter(typicalMarkModel, mark)));
+
+        // different existing bookmarks -> returns false
+        Mark markWithOneDuplicate = new Mark();
+        markWithOneDuplicate.setBookmarks(Arrays.asList(ALICE));
+        Mark markWithTwoDuplicates = new Mark();
+        markWithTwoDuplicates.setBookmarks(Arrays.asList(ALICE, BENSON));
+        assertFalse(new MarkImporter(typicalMarkModel, markWithOneDuplicate).equals(
+                new MarkImporter(typicalMarkModel, markWithTwoDuplicates)));
 
         // different bookmarks to import -> returns false
         Mark differentMark = new Mark();

--- a/src/test/java/seedu/mark/logic/commands/MarkImporterTest.java
+++ b/src/test/java/seedu/mark/logic/commands/MarkImporterTest.java
@@ -3,7 +3,6 @@ package seedu.mark.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.mark.testutil.TypicalBookmarks.getTypicalBookmarks;
-import static seedu.mark.testutil.TypicalBookmarks.getTypicalFolderStructure;
 import static seedu.mark.testutil.TypicalBookmarks.getTypicalMark;
 
 import org.junit.jupiter.api.Test;
@@ -42,11 +41,6 @@ public class MarkImporterTest {
         // different bookmarks to import -> returns false
         Mark differentMark = new Mark();
         differentMark.setBookmarks(getTypicalBookmarks());
-        assertFalse(markImporter.equals(new MarkImporter(model, differentMark)));
-
-        // different folders to import -> returns false
-        differentMark = new Mark();
-        differentMark.setFolderStructure(getTypicalFolderStructure());
         assertFalse(markImporter.equals(new MarkImporter(model, differentMark)));
     }
 }

--- a/src/test/java/seedu/mark/model/ModelStub.java
+++ b/src/test/java/seedu/mark/model/ModelStub.java
@@ -14,7 +14,6 @@ import seedu.mark.model.autotag.SelectiveBookmarkTagger;
 import seedu.mark.model.bookmark.Bookmark;
 import seedu.mark.model.bookmark.Folder;
 import seedu.mark.model.bookmark.Url;
-import seedu.mark.model.folderstructure.FolderStructure;
 import seedu.mark.model.reminder.Reminder;
 
 /**
@@ -108,11 +107,6 @@ public class ModelStub implements Model {
 
     @Override
     public boolean hasFolder(Folder folder) {
-        throw new AssertionError("This method should not be called.");
-    }
-
-    @Override
-    public void addFolders(FolderStructure foldersToAdd) {
         throw new AssertionError("This method should not be called.");
     }
 


### PR DESCRIPTION
Will not be importing folders due to the complexity of figuring out which folders in the `folderStructure` need to be imported.

PR summary:
* Removes unused importFolder methods, like #114 did previously.
* Imports bookmarks with no existing folders into the folder `ImportedBookmarks` (instead of `ROOT`)
* Updates User Guide with some details about how bookmarks are imported.

No change:
* Bookmarks with existing folders (same name) are imported into folders with the corresponding names, even if the folder structure is different.