### PR TITLE
Add back GotoCommandResult and improve test coverage

### DIFF
--- a/src/main/java/seedu/mark/logic/commands/ExpandCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/ExpandCommand.java
@@ -20,7 +20,7 @@ public class ExpandCommand extends Command {
             + "Parameters: [LEVEL] (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_GOTO_BOOKMARK_ACKNOWLEDGEMENT = "Expanding folders by %1$d level(s)";
+    public static final String MESSAGE_EXPAND_FOLDER_ACKNOWLEDGEMENT = "Expanding folders by %1$d level(s)";
 
     private final int levelsToExpand;
 
@@ -33,7 +33,7 @@ public class ExpandCommand extends Command {
         requireAllNonNull(model, storage);
 
         return new ExpandCommandResult(
-                String.format(MESSAGE_GOTO_BOOKMARK_ACKNOWLEDGEMENT, levelsToExpand), levelsToExpand);
+                String.format(MESSAGE_EXPAND_FOLDER_ACKNOWLEDGEMENT, levelsToExpand), levelsToExpand);
     }
 
     @Override

--- a/src/main/java/seedu/mark/logic/commands/GotoCommand.java
+++ b/src/main/java/seedu/mark/logic/commands/GotoCommand.java
@@ -8,6 +8,7 @@ import seedu.mark.commons.core.Messages;
 import seedu.mark.commons.core.index.Index;
 import seedu.mark.logic.commands.exceptions.CommandException;
 import seedu.mark.logic.commands.results.CommandResult;
+import seedu.mark.logic.commands.results.GotoCommandResult;
 import seedu.mark.model.Model;
 import seedu.mark.model.bookmark.Bookmark;
 import seedu.mark.storage.Storage;
@@ -45,7 +46,7 @@ public class GotoCommand extends Command {
         Bookmark bookmarkToOpen = lastShownList.get(targetIndex.getZeroBased());
         model.setCurrentUrl(bookmarkToOpen.getUrl());
 
-        return new CommandResult(String.format(MESSAGE_GOTO_BOOKMARK_ACKNOWLEDGEMENT, bookmarkToOpen));
+        return new GotoCommandResult(String.format(MESSAGE_GOTO_BOOKMARK_ACKNOWLEDGEMENT, bookmarkToOpen));
     }
 
     @Override

--- a/src/main/java/seedu/mark/logic/commands/results/CommandResult.java
+++ b/src/main/java/seedu/mark/logic/commands/results/CommandResult.java
@@ -56,7 +56,8 @@ public class CommandResult {
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
                 && isShowHelp() == otherCommandResult.isShowHelp()
                 && isExit() == otherCommandResult.isExit()
-                && getTab() == otherCommandResult.getTab();
+                && getTab() == otherCommandResult.getTab()
+                && getLevelsToExpand() == otherCommandResult.getLevelsToExpand();
     }
 
     @Override
@@ -64,7 +65,8 @@ public class CommandResult {
         return Objects.hash(feedbackToUser,
                 isShowHelp(),
                 isExit(),
-                getTab());
+                getTab(),
+                getLevelsToExpand());
     }
 
 }

--- a/src/main/java/seedu/mark/logic/commands/results/GotoCommandResult.java
+++ b/src/main/java/seedu/mark/logic/commands/results/GotoCommandResult.java
@@ -1,0 +1,23 @@
+package seedu.mark.logic.commands.results;
+
+import seedu.mark.logic.commands.TabCommand;
+
+/**
+ * Represents the result of an goto command execution.
+ */
+public class GotoCommandResult extends CommandResult {
+
+    /**
+     * Constructs a {@code GotoCommandResult} with the feedback.
+     *
+     * @param feedbackToUser the feedback to the user
+     */
+    public GotoCommandResult(String feedbackToUser) {
+        super(feedbackToUser);
+    }
+
+    @Override
+    public TabCommand.Tab getTab() {
+        return TabCommand.Tab.ONLINE;
+    }
+}

--- a/src/main/java/seedu/mark/logic/parser/CollapseCommandParser.java
+++ b/src/main/java/seedu/mark/logic/parser/CollapseCommandParser.java
@@ -19,7 +19,7 @@ public class CollapseCommandParser implements Parser<CollapseCommand> {
                 return new CollapseCommand(1);
             }
             if (!StringUtil.isNonZeroUnsignedInteger(trimmedArgs)) {
-                throw new ParseException("LEVELS is not a non-zero unsigned integer.");
+                throw new ParseException("LEVEL is not a non-zero unsigned integer.");
             }
             int levels = Integer.parseInt(trimmedArgs);
             return new CollapseCommand(levels);

--- a/src/main/java/seedu/mark/logic/parser/ExpandCommandParser.java
+++ b/src/main/java/seedu/mark/logic/parser/ExpandCommandParser.java
@@ -19,7 +19,7 @@ public class ExpandCommandParser implements Parser<ExpandCommand> {
                 return new ExpandCommand(1);
             }
             if (!StringUtil.isNonZeroUnsignedInteger(trimmedArgs)) {
-                throw new ParseException("LEVELS is not a non-zero unsigned integer.");
+                throw new ParseException("LEVEL is not a non-zero unsigned integer.");
             }
             int levels = Integer.parseInt(trimmedArgs);
             return new ExpandCommand(levels);

--- a/src/main/java/seedu/mark/logic/parser/RedoCommandParser.java
+++ b/src/main/java/seedu/mark/logic/parser/RedoCommandParser.java
@@ -10,6 +10,7 @@ import seedu.mark.logic.parser.exceptions.ParseException;
  * Parses input arguments and creates a new RedoCommand object
  */
 public class RedoCommandParser implements Parser<RedoCommand> {
+
     /**
      * Parses the given {@code String} of arguments in the context of the RedoCommand
      * and returns a RedoCommand object for execution.

--- a/src/main/resources/view/BrowserPanel.fxml
+++ b/src/main/resources/view/BrowserPanel.fxml
@@ -26,8 +26,7 @@
             </graphic>
         </Button>
     </HBox>
-
-    <StackPane>
+    <StackPane VBox.vgrow="ALWAYS">
         <WebView fx:id="browser"/>
     </StackPane>
 </VBox>

--- a/src/test/java/seedu/mark/logic/commands/CollapseCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/CollapseCommandTest.java
@@ -1,0 +1,51 @@
+package seedu.mark.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.mark.logic.commands.CollapseCommand.MESSAGE_COLLAPSE_FOLDER_ACKNOWLEDGEMENT;
+import static seedu.mark.logic.commands.CommandTestUtil.assertCommandSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.mark.logic.commands.results.CommandResult;
+import seedu.mark.logic.commands.results.ExpandCommandResult;
+import seedu.mark.model.Model;
+import seedu.mark.model.ModelManager;
+import seedu.mark.storage.StorageStub;
+
+public class CollapseCommandTest {
+
+    private Model model = new ModelManager();
+    private Model expectedModel = new ModelManager();
+
+    @Test
+    public void execute_exit_success() {
+        int levelsToCollapse = 2;
+        CommandResult expectedCommandResult = new ExpandCommandResult(
+                String.format(MESSAGE_COLLAPSE_FOLDER_ACKNOWLEDGEMENT, levelsToCollapse), -levelsToCollapse);
+        assertCommandSuccess(new CollapseCommand(levelsToCollapse), model, new StorageStub(),
+                expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void equals() {
+        CollapseCommand collapseOneCommand = new CollapseCommand(1);
+        CollapseCommand collapseTwoCommand = new CollapseCommand(2);
+
+        // same object -> returns true
+        assertTrue(collapseOneCommand.equals(collapseOneCommand));
+
+        // same values -> returns true
+        CollapseCommand collapseOneCommandCopy = new CollapseCommand(1);
+        assertTrue(collapseOneCommand.equals(collapseOneCommandCopy));
+
+        // different types -> returns false
+        assertFalse(collapseOneCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(collapseOneCommand.equals(null));
+
+        // different levelsToCollapse -> returns false
+        assertFalse(collapseOneCommand.equals(collapseTwoCommand));
+    }
+}

--- a/src/test/java/seedu/mark/logic/commands/ExpandCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/ExpandCommandTest.java
@@ -1,0 +1,51 @@
+package seedu.mark.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.mark.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.mark.logic.commands.ExpandCommand.MESSAGE_EXPAND_FOLDER_ACKNOWLEDGEMENT;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.mark.logic.commands.results.CommandResult;
+import seedu.mark.logic.commands.results.ExpandCommandResult;
+import seedu.mark.model.Model;
+import seedu.mark.model.ModelManager;
+import seedu.mark.storage.StorageStub;
+
+public class ExpandCommandTest {
+
+    private Model model = new ModelManager();
+    private Model expectedModel = new ModelManager();
+
+    @Test
+    public void execute_exit_success() {
+        int levelsToExpand = 2;
+        CommandResult expectedCommandResult = new ExpandCommandResult(
+                String.format(MESSAGE_EXPAND_FOLDER_ACKNOWLEDGEMENT, levelsToExpand), levelsToExpand);
+        assertCommandSuccess(new ExpandCommand(levelsToExpand), model, new StorageStub(),
+                expectedCommandResult, expectedModel);
+    }
+
+    @Test
+    public void equals() {
+        ExpandCommand expandOneCommand = new ExpandCommand(1);
+        ExpandCommand expandTwoCommand = new ExpandCommand(2);
+
+        // same object -> returns true
+        assertTrue(expandOneCommand.equals(expandOneCommand));
+
+        // same values -> returns true
+        ExpandCommand expandOneCommandCopy = new ExpandCommand(1);
+        assertTrue(expandOneCommand.equals(expandOneCommandCopy));
+
+        // different types -> returns false
+        assertFalse(expandOneCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(expandOneCommand.equals(null));
+
+        // different levelsToExpand -> returns false
+        assertFalse(expandOneCommand.equals(expandTwoCommand));
+    }
+}

--- a/src/test/java/seedu/mark/logic/commands/GotoCommandTest.java
+++ b/src/test/java/seedu/mark/logic/commands/GotoCommandTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import seedu.mark.commons.core.Messages;
 import seedu.mark.commons.core.index.Index;
 import seedu.mark.logic.commands.results.CommandResult;
+import seedu.mark.logic.commands.results.GotoCommandResult;
 import seedu.mark.model.Model;
 import seedu.mark.model.ModelManager;
 import seedu.mark.model.UserPrefs;
@@ -22,6 +23,7 @@ import seedu.mark.storage.Storage;
 import seedu.mark.storage.StorageStub;
 
 public class GotoCommandTest {
+
     private Model model = new ModelManager(getTypicalMark(), new UserPrefs());
     private Model expectedModel = new ModelManager(getTypicalMark(), new UserPrefs());
     private Storage storage = new StorageStub();
@@ -33,7 +35,7 @@ public class GotoCommandTest {
 
         expectedModel.setCurrentUrl(bookmarkToOpen.getUrl());
         String expectedMessage = String.format(GotoCommand.MESSAGE_GOTO_BOOKMARK_ACKNOWLEDGEMENT, bookmarkToOpen);
-        CommandResult expectedCommandResult = new CommandResult(expectedMessage);
+        CommandResult expectedCommandResult = new GotoCommandResult(expectedMessage);
 
         assertCommandSuccess(gotoCommand, model, storage, expectedCommandResult, expectedModel);
     }
@@ -56,7 +58,7 @@ public class GotoCommandTest {
 
         expectedModel.setCurrentUrl(bookmarkToOpen.getUrl());
         String expectedMessage = String.format(GotoCommand.MESSAGE_GOTO_BOOKMARK_ACKNOWLEDGEMENT, bookmarkToOpen);
-        CommandResult expectedCommandResult = new CommandResult(expectedMessage);
+        CommandResult expectedCommandResult = new GotoCommandResult(expectedMessage);
 
         assertCommandSuccess(gotoCommand, model, storage, expectedCommandResult, expectedModel);
     }

--- a/src/test/java/seedu/mark/logic/commands/results/CommandResultTest.java
+++ b/src/test/java/seedu/mark/logic/commands/results/CommandResultTest.java
@@ -44,6 +44,9 @@ public class CommandResultTest {
 
         // different getTab() value -> returns false
         assertFalse(commandResult.equals(new TabCommandResult("feedback", TabCommand.Tab.DASHBOARD)));
+
+        // different getLevelsToExpand() value -> returns false
+        assertFalse(commandResult.equals(new ExpandCommandResult("feedback", 2)));
     }
 
     @Test
@@ -65,5 +68,9 @@ public class CommandResultTest {
         // different getTab() value -> returns different hashcode
         assertNotEquals(commandResult.hashCode(),
                 new TabCommandResult("feedback", TabCommand.Tab.DASHBOARD).hashCode());
+
+        // different getLevelsToExpand() value -> returns different hashcode
+        assertNotEquals(commandResult.hashCode(),
+                new ExpandCommandResult("feedback", 2).hashCode());
     }
 }

--- a/src/test/java/seedu/mark/logic/commands/results/ExitCommandResultTest.java
+++ b/src/test/java/seedu/mark/logic/commands/results/ExitCommandResultTest.java
@@ -1,5 +1,6 @@
 package seedu.mark.logic.commands.results;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -15,5 +16,6 @@ public class ExitCommandResultTest {
         assertTrue(commandResult.isExit());
         assertFalse(commandResult.isShowHelp());
         assertNull(commandResult.getTab());
+        assertEquals(commandResult.getLevelsToExpand(), 0);
     }
 }

--- a/src/test/java/seedu/mark/logic/commands/results/ExpandCommandResultTest.java
+++ b/src/test/java/seedu/mark/logic/commands/results/ExpandCommandResultTest.java
@@ -11,8 +11,8 @@ public class ExpandCommandResultTest {
     @Test
     public void isExpand() {
         int levelsToExpand = 1;
-        ExpandCommandResult result =
-                new ExpandCommandResult("feedback", levelsToExpand);
+        ExpandCommandResult result = new ExpandCommandResult("feedback", levelsToExpand);
+
         assertEquals(result.getLevelsToExpand(), levelsToExpand);
         assertFalse(result.isExit());
         assertFalse(result.isShowHelp());

--- a/src/test/java/seedu/mark/logic/commands/results/GotoCommandResultTest.java
+++ b/src/test/java/seedu/mark/logic/commands/results/GotoCommandResultTest.java
@@ -7,13 +7,13 @@ import org.junit.jupiter.api.Test;
 
 import seedu.mark.logic.commands.TabCommand;
 
-public class TabCommandResultTest {
+public class GotoCommandResultTest {
 
     @Test
     public void getTab() {
-        TabCommandResult commandResult = new TabCommandResult("feedback", TabCommand.Tab.DASHBOARD);
+        GotoCommandResult commandResult = new GotoCommandResult("feedback");
 
-        assertEquals(TabCommand.Tab.DASHBOARD, commandResult.getTab());
+        assertEquals(TabCommand.Tab.ONLINE, commandResult.getTab());
         assertFalse(commandResult.isShowHelp());
         assertFalse(commandResult.isExit());
         assertEquals(commandResult.getLevelsToExpand(), 0);

--- a/src/test/java/seedu/mark/logic/commands/results/HelpCommandResultTest.java
+++ b/src/test/java/seedu/mark/logic/commands/results/HelpCommandResultTest.java
@@ -1,5 +1,6 @@
 package seedu.mark.logic.commands.results;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -15,5 +16,6 @@ public class HelpCommandResultTest {
         assertTrue(commandResult.isShowHelp());
         assertFalse(commandResult.isExit());
         assertNull(commandResult.getTab());
+        assertEquals(commandResult.getLevelsToExpand(), 0);
     }
 }

--- a/src/test/java/seedu/mark/logic/commands/results/OfflineCommandResultTest.java
+++ b/src/test/java/seedu/mark/logic/commands/results/OfflineCommandResultTest.java
@@ -7,13 +7,13 @@ import org.junit.jupiter.api.Test;
 
 import seedu.mark.logic.commands.TabCommand;
 
-public class TabCommandResultTest {
+public class OfflineCommandResultTest {
 
     @Test
     public void getTab() {
-        TabCommandResult commandResult = new TabCommandResult("feedback", TabCommand.Tab.DASHBOARD);
+        OfflineCommandResult commandResult = new OfflineCommandResult("feedback");
 
-        assertEquals(TabCommand.Tab.DASHBOARD, commandResult.getTab());
+        assertEquals(TabCommand.Tab.OFFLINE, commandResult.getTab());
         assertFalse(commandResult.isShowHelp());
         assertFalse(commandResult.isExit());
         assertEquals(commandResult.getLevelsToExpand(), 0);

--- a/src/test/java/seedu/mark/logic/parser/CollapseCommandParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/CollapseCommandParserTest.java
@@ -1,0 +1,49 @@
+package seedu.mark.logic.parser;
+
+import static seedu.mark.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.mark.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.mark.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.mark.logic.commands.CollapseCommand;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the CollapseCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the CollapseCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class CollapseCommandParserTest {
+
+    private CollapseCommandParser parser = new CollapseCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsCollapseCommand() {
+        assertParseSuccess(parser, "2", new CollapseCommand(2));
+    }
+
+    @Test
+    public void parse_emptyArgs_returnsCollapseCommand() {
+        assertParseSuccess(parser, "", new CollapseCommand(1));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CollapseCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_zero_throwsParseException() {
+        assertParseFailure(parser, "0",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CollapseCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_negativeNumber_throwsParseException() {
+        assertParseFailure(parser, "-1",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CollapseCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/mark/logic/parser/ExpandCommandParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/ExpandCommandParserTest.java
@@ -1,0 +1,49 @@
+package seedu.mark.logic.parser;
+
+import static seedu.mark.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.mark.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.mark.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.mark.logic.commands.ExpandCommand;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the ExpandCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the ExpandCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class ExpandCommandParserTest {
+
+    private ExpandCommandParser parser = new ExpandCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsExpandCommand() {
+        assertParseSuccess(parser, "2", new ExpandCommand(2));
+    }
+
+    @Test
+    public void parse_emptyArgs_returnsExpandCommand() {
+        assertParseSuccess(parser, "", new ExpandCommand(1));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExpandCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_zero_throwsParseException() {
+        assertParseFailure(parser, "0",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExpandCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_negativeNumber_throwsParseException() {
+        assertParseFailure(parser, "-1",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExpandCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/mark/logic/parser/RedoCommandParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/RedoCommandParserTest.java
@@ -26,4 +26,14 @@ public class RedoCommandParserTest {
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, RedoCommand.MESSAGE_USAGE));
     }
+
+    @Test
+    public void parse_zero_throwsParseException() {
+        assertParseFailure(parser, "0", String.format(MESSAGE_INVALID_COMMAND_FORMAT, RedoCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_negativeNumber_throwsParseException() {
+        assertParseFailure(parser, "-1", String.format(MESSAGE_INVALID_COMMAND_FORMAT, RedoCommand.MESSAGE_USAGE));
+    }
 }

--- a/src/test/java/seedu/mark/logic/parser/UndoCommandParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/UndoCommandParserTest.java
@@ -26,4 +26,14 @@ public class UndoCommandParserTest {
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, UndoCommand.MESSAGE_USAGE));
     }
+
+    @Test
+    public void parse_zero_throwsParseException() {
+        assertParseFailure(parser, "0", String.format(MESSAGE_INVALID_COMMAND_FORMAT, UndoCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_negativeNumber_throwsParseException() {
+        assertParseFailure(parser, "-1", String.format(MESSAGE_INVALID_COMMAND_FORMAT, UndoCommand.MESSAGE_USAGE));
+    }
 }

--- a/src/test/java/seedu/mark/model/MarkStateRecordTest.java
+++ b/src/test/java/seedu/mark/model/MarkStateRecordTest.java
@@ -1,5 +1,6 @@
 package seedu.mark.model;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.mark.testutil.Assert.assertThrows;
@@ -24,6 +25,18 @@ public class MarkStateRecordTest {
     @Test
     public void constructor_nullRecord_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new MarkStateRecord(null, new Mark()));
+    }
+
+    @Test
+    public void getRecord_success() {
+        MarkStateRecord markStateRecord = new MarkStateRecord("record", markWithAmy);
+        assertEquals("record", markStateRecord.getRecord());
+    }
+
+    @Test
+    public void getState_success() {
+        MarkStateRecord markStateRecord = new MarkStateRecord("record", markWithAmy);
+        assertEquals(markWithAmy, markStateRecord.getState());
     }
 
     @Test

--- a/src/test/java/seedu/mark/model/VersionedMarkTest.java
+++ b/src/test/java/seedu/mark/model/VersionedMarkTest.java
@@ -266,7 +266,6 @@ public class VersionedMarkTest {
         assertThrows(VersionedMark.CannotRedoMarkException.class, () -> versionedMark.redo(1));
     }
 
-    //
     @Test
     public void redo_multipleMarkPointerAtEndOfStateList_throwsCannotRedoMarkException() {
         VersionedMark versionedMark = prepareMarkList(
@@ -292,7 +291,7 @@ public class VersionedMarkTest {
         // different types -> returns false
         assertFalse(versionedMark.equals(1));
 
-        // different state list -> returns false
+        // different state record list -> returns false
         VersionedMark differentMarkStateRecords = prepareMarkList(markWithBob, markWithCarl);
         assertFalse(versionedMark.equals(differentMarkStateRecords));
 


### PR DESCRIPTION
GotoCommandResult is added back to account for the following case:
- open 1
- tab 3
- open 1
If we only switch tab when currentUrl changes, the last command wont switch tab as the currentUrl does not change.

Others:
- rename some variables
- add tests to pass coveralls
- resize the web view (make it fit the browser panel)