### PR TITLE
Validate file names for Import and Export

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -321,6 +321,7 @@ Format: `*export* [FILENAME]`
 +
 `FILENAME` should not include the file extension. E.g. `myBookmarks` and not
 `myBookmarks.json`
+* `FILENAME` should consist of only alphanumeric characters, hyphens, and/or underscores.
 * The data file is saved at `[applicationHome]/data/bookmarks/FILENAME.json`.
 If the given file already exists, it is overwritten.
 ****
@@ -346,6 +347,7 @@ Format: `*import* FILENAME`
 ****
 * `FILENAME` is case sensitive and should not include the file extension. E.g.
 `myBookmarks` and not `myBookmarks.json`
+* `FILENAME` should consist of only alphanumeric characters, hyphens, and/or underscores.
 * `FILENAME.json` should be a file stored in the folder
 `[applicationHome]/data/bookmarks/`.
 * The file corresponding to `FILENAME` should have a valid format, identical

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -103,9 +103,9 @@ specified.
 f/CS2103T r/Contains textbook & important deadlines` +
 Bookmarks the given website, names it `Module Website`, and adds it to the folder `CS2103T`.
 The new bookmark's remark is `Contains textbook & important deadlines`.
-* `*add* u/www.youtube.com/watch?v=9AMcN-wkspU n/IntelliJ Tips and Tricks t/video t/watch-later`
+* `*add* u/https://www.youtube.com/watch?v=9AMcN-wkspU n/IntelliJ Tips and Tricks t/video t/watchLater`
 Bookmarks the given website, names it `IntelliJ Tips and Tricks`. The new bookmark's tags include
-`video` and `watch-later`.
+`video` and `watchLater`.
 
 [[folder]]
 === Adding a new folder: *`folder`*

--- a/src/main/java/seedu/mark/commons/core/Messages.java
+++ b/src/main/java/seedu/mark/commons/core/Messages.java
@@ -11,7 +11,4 @@ public class Messages {
     public static final String MESSAGE_BOOKMARKS_LISTED_OVERVIEW = "%1$d bookmarks listed!";
     public static final String MESSAGE_INVALID_REMINDER_DISPLAYED_INDEX = "The reminder index provided is invalid";
     public static final String MESSAGE_FOLDER_NOT_FOUND = "Folder %1$s does not exist";
-    public static final String MESSAGE_FILE_NAME_INCLUDES_EXTENSION =
-            "FILENAME should not include the file extension '.json'";
-
 }

--- a/src/main/java/seedu/mark/commons/core/Messages.java
+++ b/src/main/java/seedu/mark/commons/core/Messages.java
@@ -11,5 +11,7 @@ public class Messages {
     public static final String MESSAGE_BOOKMARKS_LISTED_OVERVIEW = "%1$d bookmarks listed!";
     public static final String MESSAGE_INVALID_REMINDER_DISPLAYED_INDEX = "The reminder index provided is invalid";
     public static final String MESSAGE_FOLDER_NOT_FOUND = "Folder %1$s does not exist";
+    public static final String MESSAGE_FILE_NAME_INCLUDES_EXTENSION =
+            "FILENAME should not include the file extension '.json'";
 
 }

--- a/src/main/java/seedu/mark/logic/parser/ExportCommandParser.java
+++ b/src/main/java/seedu/mark/logic/parser/ExportCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.mark.logic.parser;
 
+import static seedu.mark.commons.core.Messages.MESSAGE_FILE_NAME_INCLUDES_EXTENSION;
 import static seedu.mark.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.nio.file.Path;
@@ -24,6 +25,10 @@ public class ExportCommandParser implements Parser<ExportCommand> {
         if (trimmedArgs.isEmpty() || trimmedArgs.split(" ").length != 1) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE));
+        }
+
+        if (trimmedArgs.endsWith(".json")) {
+            throw new ParseException(MESSAGE_FILE_NAME_INCLUDES_EXTENSION);
         }
 
         Path destinationFile = Path.of("data", "bookmarks", trimmedArgs + ".json");

--- a/src/main/java/seedu/mark/logic/parser/ExportCommandParser.java
+++ b/src/main/java/seedu/mark/logic/parser/ExportCommandParser.java
@@ -1,7 +1,8 @@
 package seedu.mark.logic.parser;
 
-import static seedu.mark.commons.core.Messages.MESSAGE_FILE_NAME_INCLUDES_EXTENSION;
 import static seedu.mark.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.mark.logic.parser.ParserUtil.MESSAGE_FILE_NAME_INCLUDES_EXTENSION;
+import static seedu.mark.logic.parser.ParserUtil.MESSAGE_INVALID_FILE_NAME;
 
 import java.nio.file.Path;
 
@@ -21,16 +22,15 @@ public class ExportCommandParser implements Parser<ExportCommand> {
     public ExportCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
 
-        // args must contain exactly one word
         if (trimmedArgs.isEmpty() || trimmedArgs.split(" ").length != 1) {
+            // args must contain exactly one word
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE));
-        }
-
-        if (trimmedArgs.endsWith(".json")) {
+        } else if (trimmedArgs.endsWith(".json")) {
             throw new ParseException(MESSAGE_FILE_NAME_INCLUDES_EXTENSION);
+        } else if (!ParserUtil.isValidFilename(trimmedArgs)) {
+            throw new ParseException(MESSAGE_INVALID_FILE_NAME);
         }
-
         Path destinationFile = Path.of("data", "bookmarks", trimmedArgs + ".json");
 
         return new ExportCommand(destinationFile);

--- a/src/main/java/seedu/mark/logic/parser/ImportCommandParser.java
+++ b/src/main/java/seedu/mark/logic/parser/ImportCommandParser.java
@@ -1,7 +1,8 @@
 package seedu.mark.logic.parser;
 
-import static seedu.mark.commons.core.Messages.MESSAGE_FILE_NAME_INCLUDES_EXTENSION;
 import static seedu.mark.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.mark.logic.parser.ParserUtil.MESSAGE_FILE_NAME_INCLUDES_EXTENSION;
+import static seedu.mark.logic.parser.ParserUtil.MESSAGE_INVALID_FILE_NAME;
 
 import java.nio.file.Path;
 
@@ -21,14 +22,14 @@ public class ImportCommandParser implements Parser<ImportCommand> {
     public ImportCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
 
-        // args must contain exactly one word
         if (trimmedArgs.isEmpty() || trimmedArgs.split(" ").length != 1) {
+            // args must contain exactly one word
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
-        }
-
-        if (trimmedArgs.endsWith(".json")) {
+        } else if (trimmedArgs.endsWith(".json")) {
             throw new ParseException(MESSAGE_FILE_NAME_INCLUDES_EXTENSION);
+        } else if (!ParserUtil.isValidFilename(trimmedArgs)) {
+            throw new ParseException(MESSAGE_INVALID_FILE_NAME);
         }
 
         Path sourceFile = Path.of("data", "bookmarks", trimmedArgs + ".json");

--- a/src/main/java/seedu/mark/logic/parser/ImportCommandParser.java
+++ b/src/main/java/seedu/mark/logic/parser/ImportCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.mark.logic.parser;
 
+import static seedu.mark.commons.core.Messages.MESSAGE_FILE_NAME_INCLUDES_EXTENSION;
 import static seedu.mark.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.nio.file.Path;
@@ -24,6 +25,10 @@ public class ImportCommandParser implements Parser<ImportCommand> {
         if (trimmedArgs.isEmpty() || trimmedArgs.split(" ").length != 1) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
+        }
+
+        if (trimmedArgs.endsWith(".json")) {
+            throw new ParseException(MESSAGE_FILE_NAME_INCLUDES_EXTENSION);
         }
 
         Path sourceFile = Path.of("data", "bookmarks", trimmedArgs + ".json");

--- a/src/main/java/seedu/mark/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/mark/logic/parser/ParserUtil.java
@@ -28,6 +28,10 @@ public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
     public static final String MESSAGE_INVALID_BOOL = "Boolean options should be spelt either true or false.";
+    public static final String MESSAGE_INVALID_FILE_NAME =
+            "FILENAME should only contain alphanumeric characters, hyphens '-', or underscores '_'.";
+    public static final String MESSAGE_FILE_NAME_INCLUDES_EXTENSION =
+            "FILENAME should not include the file extension '.json'";
 
     private static final String DATE_FORMATTER = "dd/MM/yyyy HHmm";
     protected static final String MESSAGE_INVALID_TIME_FORMAT =
@@ -240,4 +244,14 @@ public class ParserUtil {
         }
     }
 
+    /**
+     * Checks whether the given {@code String} is a valid filename i.e. consists
+     * of only alphanumeric characters, hyphens, and/or underscores.
+     *
+     * @param name String representing filename to be checked
+     * @return {@code true} if {@code name} is a valid filename and {@code false} otherwise.
+     */
+    public static boolean isValidFilename(String name) {
+        return name.matches("[\\p{Alnum}\\-_]+");
+    }
 }

--- a/src/test/java/seedu/mark/logic/parser/ExportCommandParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/ExportCommandParserTest.java
@@ -1,9 +1,10 @@
 package seedu.mark.logic.parser;
 
-import static seedu.mark.commons.core.Messages.MESSAGE_FILE_NAME_INCLUDES_EXTENSION;
 import static seedu.mark.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.mark.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.mark.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.mark.logic.parser.ParserUtil.MESSAGE_FILE_NAME_INCLUDES_EXTENSION;
+import static seedu.mark.logic.parser.ParserUtil.MESSAGE_INVALID_FILE_NAME;
 
 import java.nio.file.Path;
 
@@ -28,6 +29,10 @@ public class ExportCommandParserTest {
         // file name ends with .json
         assertParseFailure(parser, "myBookmarks.json",
                 MESSAGE_FILE_NAME_INCLUDES_EXTENSION);
+
+        // invalid file name
+        assertParseFailure(parser, "invalid$$",
+                MESSAGE_INVALID_FILE_NAME);
     }
 
     @Test
@@ -39,6 +44,10 @@ public class ExportCommandParserTest {
 
         // leading and trailing whitespaces
         assertParseSuccess(parser, " \n myBookmarks \n \t", expectedExportCommand);
+
+        // hyphen and underscore
+        expectedExportCommand = new ExportCommand(Path.of("data", "bookmarks", "my-Bookmarks_copy.json"));
+        assertParseSuccess(parser, "my-Bookmarks_copy", expectedExportCommand);
     }
 
 }

--- a/src/test/java/seedu/mark/logic/parser/ExportCommandParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/ExportCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.mark.logic.parser;
 
+import static seedu.mark.commons.core.Messages.MESSAGE_FILE_NAME_INCLUDES_EXTENSION;
 import static seedu.mark.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.mark.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.mark.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -23,6 +24,10 @@ public class ExportCommandParserTest {
         // multiple words
         assertParseFailure(parser, "more than one word",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE));
+
+        // file name ends with .json
+        assertParseFailure(parser, "myBookmarks.json",
+                MESSAGE_FILE_NAME_INCLUDES_EXTENSION);
     }
 
     @Test

--- a/src/test/java/seedu/mark/logic/parser/ImportCommandParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/ImportCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.mark.logic.parser;
 
+import static seedu.mark.commons.core.Messages.MESSAGE_FILE_NAME_INCLUDES_EXTENSION;
 import static seedu.mark.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.mark.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.mark.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -23,6 +24,10 @@ public class ImportCommandParserTest {
         // multiple words
         assertParseFailure(parser, "more than one word",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
+
+        // file name ends with .json
+        assertParseFailure(parser, "myBookmarks.json",
+                MESSAGE_FILE_NAME_INCLUDES_EXTENSION);
     }
 
     @Test

--- a/src/test/java/seedu/mark/logic/parser/ImportCommandParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/ImportCommandParserTest.java
@@ -1,9 +1,10 @@
 package seedu.mark.logic.parser;
 
-import static seedu.mark.commons.core.Messages.MESSAGE_FILE_NAME_INCLUDES_EXTENSION;
 import static seedu.mark.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.mark.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.mark.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.mark.logic.parser.ParserUtil.MESSAGE_FILE_NAME_INCLUDES_EXTENSION;
+import static seedu.mark.logic.parser.ParserUtil.MESSAGE_INVALID_FILE_NAME;
 
 import java.nio.file.Path;
 
@@ -28,6 +29,10 @@ public class ImportCommandParserTest {
         // file name ends with .json
         assertParseFailure(parser, "myBookmarks.json",
                 MESSAGE_FILE_NAME_INCLUDES_EXTENSION);
+
+        // invalid file name
+        assertParseFailure(parser, "invalid$$",
+                MESSAGE_INVALID_FILE_NAME);
     }
 
     @Test
@@ -39,6 +44,10 @@ public class ImportCommandParserTest {
 
         // leading and trailing whitespaces
         assertParseSuccess(parser, " \n myBookmarks \n \t", expectedImportCommand);
+
+        // hyphen and underscore
+        expectedImportCommand = new ImportCommand(Path.of("data", "bookmarks", "my-Bookmarks_copy.json"));
+        assertParseSuccess(parser, "my-Bookmarks_copy", expectedImportCommand);
     }
 
 }


### PR DESCRIPTION
* For import and export commands, checks that:
  1. `FILENAME` does not end with `.json`.
  2. `FILENAME` only consists of alphanumeric characters, hyphens, and/or underscores.
* Updates tests and UserGuide for import/export too.

Others:
* Update add command example (make the URL and tag name valid).

Fixes #199 #198 #187.