### PR TITLE
Update User guide to mark out areas that need screenshots

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -23,7 +23,7 @@ bookmarks*. More importantly, it is *optimized for those who prefer to
 work with a Command Line Interface* (CLI) while still having the
 benefits of a Graphical User Interface (GUI). If you can type fast, Mark
 can get your bookmark organisation and note-taking done faster than
-traditional GUI apps. Interested? Jump to
+traditional GUI apps. Interested? Move on to
 <<Quick Start>> to get
 started. Enjoy!
 
@@ -41,7 +41,7 @@ image::Ui.png[width="790"]
 .  Type the command in the command box and press kbd:[Enter] to execute it. +
 e.g. typing *`help`* and pressing kbd:[Enter] will open the help window.
 +
-Some example commands you can try:
+Here are some example commands that you can try:
 
 * *`list`* : lists all bookmarks
 * *`folder Tutorials`* : create a folder named `Tutorials`
@@ -51,6 +51,25 @@ named `Pro Git` to Mark.
 * *`exit`* : exits the app
 
 .  Refer to <<Features>> for details of each command.
+
+=== Navigating the GUI
+
+//TODO: include gui walkthru
+Upon startup, you will see this view on Mark's GUI:
+//include labelled img with these components demarcated:
+//command box
+//result/error box
+//tab buttons
+//bookmark list panel
+//dashboard: + the 4 sections
+
+As you can see, upon entering Mark you will be fetched to the Dashboard tab view. Mark also has an Online
+tab view and an Offline tab view. This is what the Online tab view looks like:
+//online tab; demarcate browser
+
+This is what an Offline tab view looks like:
+//demarcate paragraph list -- called document annotation area?
+
 
 [[Features]]
 == Features
@@ -477,8 +496,8 @@ Deletes the offline copy of the second bookmark.
 [[annotate]]
 === Making annotations on an offline copy: *`annotate`*
 
-If you want to add a new annotation on the offline copy of the given bookmarked
-website, you can do so using the `annotate` command.
+If you want to add a new annotation on the offline copy of a bookmark,
+you can do so using the `annotate` command.
 With this command, you can highlight a paragraph on the offline document and
 optionally attach a supplementary note to said paragraph. You can add notes
 to justify the highlight or as content-relevant notes to refer to in future.
@@ -504,13 +523,12 @@ Format: `*annotate* INDEX p/PARA_NUM [n/NOTES] [h/HIGHLIGHT_COLOUR=yellow]`
 
 For example:
 
-* Provide the index of the bookmark, the paragraph identifier of the paragraph to annotate and any notes or highlight you want to add.
- `*annotate* 1 p/p2 n/summary of paragraph h/orange`
+* Input `*annotate* 1 p/p2 n/summary of paragraph h/orange` into the command box.
 
 image::AddAnnotationCommandUi1.png[]
 // offline tab, showing result after   annotate 1 p/p2
 
-* Any pre-existing annotation is overwritten. Paragraph P2 is now highlighted orange and a note with content “summary of paragraph” is attached to it.
+* Observe that any pre-existing annotation is overwritten. Paragraph P2 is now highlighted orange and a note with content “summary of paragraph” is attached to it.
 
 image::AddAnnotationCommandUi2.png[]
 // offline tab, showing result.
@@ -554,7 +572,7 @@ offline copy of bookmark 1.
 [[annotatedelete]]
 === Deleting annotations on an offline copy: *`annotate-delete`*
 
-If you want to delete highlights or notes from an offline copy of a bookmark, you can do so using the `annotate-delete` command.
+If you want to delete highlights or notes from the offline copy of a bookmark, you can do so using the `annotate-delete` command.
 You can choose to remove just the notes and/or highlight of a paragraph, or clear all annotations
 on the offline copy to revert it to a clean slate. You can also choose to remove a note from the
 <<stray-notes,_General notes section_>>.
@@ -568,7 +586,14 @@ Format: `*annotate-delete* INDEX p/PARA_NUM [n/KEEP_NOTES=false] [h/KEEP_HIGHLIG
 
 For example:
 
-* Provide the index of the bookmark, the paragraph identifier of the paragraph to annotate and optionally whether
+* Input `*annotate-delete* 1 p/p2 n/true` into the command box.
+
+image::DeleteAnnotationCommandUi1.png[]
+// offline tab, after   annotate 1 p/p2 h/pink n/this note is originally not general
+
+* Observe that the highlight of paragraph 2 if removed and the note is moved to the _General notes section_.
+
+image::DeleteAnnotationCommandUi2.png[]
 
 
 ****
@@ -586,31 +611,27 @@ the highlight will be removed. `KEEP_HIGHLIGHT` is `false` by default.
  If `KEEP_HIGHLIGHT`` is invalid, a warning message will be displayed.
 ****
 
-Examples:
+Other examples:
 
 * `*annotate-delete* 1 p/p2` +
 This removes both the note and highlight from paragraph 2 in the offline copy of bookmark 1.
 
-* `*annotate-delete* 1 p/p2 n/true` +
-This removes the highlight of paragraph 2 and moves the note to _General notes section_ in the offline copy of bookmark 1.
-
 * `*annotate-delete* 1 p/p2 h/true` +
 This removes the note of paragraph 2 in the offline copy of bookmark 1, leaving the highlight untouched.
 
-* `*annotate-delete* 2 p/s1` +
-This deletes the general note from phantom paragraph `S1` in the offline copy of bookmark 2.
+* `*annotate-delete* 2 p/g1` +
+This deletes the general note from phantom paragraph `G1` in the offline copy of bookmark 2.
 
 * `*annotate-delete* 1 p/all` +
 This removes all annotations of the offline copy of bookmark 1.
 
-[[annotate-edit]]
+
+[[annotateedit]]
 === Modifying annotations on an offline copy: *`annotate-edit`*
 
-This modifies existing annotations on the offline copy of the given bookmarked
-website. When you give this command, the UI will switch to the offline tab showing the results of your command.
-With this command, you can choose to overwrite the existing notes to a particular paragraph with another note, change the highlight or
-choose to move notes from a paragraph to another paragraph. This command also supports moving notes of a
-<<phantom-paragraph, phantom paragraph>> back to the main text by specifying which true paragraph to move it to.
+If you want to modify existing annotations on the offline copy of a bookmark, you can do so using the `annotate-edit` command.
+You can choose to overwrite the existing note of a particular paragraph with another note, change the highlight or
+choose to move notes from a paragraph to another paragraph. You can also use this command to move a general note to the main text by specifying which original paragraph to move it to.
 
 NOTE: While both `*annotate-edit*` and `*annotate*` can be used to change current annotation highlight and notes, `*annotate-edit*`
 allows you to shift your annotations from one paragraph to another in a single step.
@@ -618,7 +639,20 @@ allows you to shift your annotations from one paragraph to another in a single s
 Moving of notes to the <<stray-notes, _General notes section_>> is not supported. If you really want to shift them,
 use <<annotatedelete, `*annotate-delete*`>> with  `n/true` as the only optional flag you include.
 
+Upon editing an annotation, your view will be switched to the offline tab showing the results of your command.
+
 Format: `*annotate-edit* INDEX p/PARA_NUM [to/NEW_PARA_NUM] [n/NOTES] [h/HIGHLIGHT_COLOUR]`
+
+For example:
+
+* Input `*annotate-edit* 1 p/g1 to/p1 h/green` into the command box.
+
+image::EditAnnotationCommandUi1.png[]
+// offline tab after   annotate 1 p/null n/this note was once a general note
+
+* Observe that the general note removed from the bottom and attached to pararaph P1. At the same time, paragraph P1 is highlighted green.
+
+image::EditAnnotationCommandUi2.png[]
 
 ****
  * `INDEX` is the bookmark that you want to annotate offline version of.
@@ -651,7 +685,7 @@ This replaces the content of the note for paragraph 1 with "new notes" in the of
 * `*annotate-edit* 1 p/p1 h/yellow` +
 This changes the highlight colour to yellow for paragraph 1 in the offline copy of bookmark 1.
 
-* `*annotate-edit* 1 p/s2 to/p1` +
+* `*annotate-edit* 1 p/g2 to/p1` +
 This moves the general note of phantom paragraph `S2` to paragraph 1 in the offline copy of bookmark 1.
 
 * `*annotate-edit* 1 p/p2 to/p3 n/changing and moving notes` +
@@ -661,8 +695,8 @@ a note with content "changing and moving notes". The annotation on paragraph 2 i
 
 === Viewing an annotated offline copy: *`offline`*
 
-Switches to offline tab and shows offline copy of a selected bookmark. The offline view tab will
-show the latest offline copy with annotations by default.
+If you want to view the offline copy of a bookmark, you can do so using the `offline` command. Your view will be switched
+to the offline tab where the offline copy is shown.
 
 Format: `*offline* INDEX`
 //TODO: [v/VERSION = current]`

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -513,7 +513,7 @@ to newly created paragraphs that do not have any content displayed.
 General notes are found at the bottom of the page, referred to as the _General notes section_.
 
 You can choose to use this command to overwrite any existing note. However, note that when you use this command to highlight
-a phantom paragraph, Mark remembers the hidden highlight colour, but no highlight is reflected on the application.
+the paragraph of a general note, Mark remembers the hidden highlight colour, but no highlight is reflected on the application.
 
 NOTE: Paragraphs are identified using a numbered identifier that starts with either `P` or `G`. You can refer to the
 numbered identifier in the leftmost column of the offline document to check out the respective identifier for each paragraph.
@@ -539,7 +539,7 @@ image::AddAnnotationCommandUi2.png[]
  * `INDEX` is the bookmark that you want to annotate offline version of.
  If `INDEX` is invalid, a warning message will be displayed.
  * `PARA_NUM` is the numbered identifier of the paragraph to be marked.
- `PARA_NUM` must be `NULL` or it must begin with `P` or `G` (e.g. `P3`).
+ `PARA_NUM` must be `NULL` or it must begin with `P` or `G` (e.g. `P3`). `PARA_NUM` is case-insensitive.
  If `PARA_NUM` is invalid, a warning message will be displayed.
  * `NOTES` is the content of notes to add.
  * `HIGHLIGHT_COLOUR` is either `orange`, `pink`, `green` or `yellow`. This selects
@@ -578,7 +578,7 @@ on the offline copy to revert it to a clean slate. You can also choose to remove
 <<stray-notes,_General notes section_>>.
 
 If the given paragraph does not have any annotations to remove, nothing is performed.
-Also, you cannot choose to remove only the highlight from a phantom paragraph since it does not display a highlight in the first place.
+Also, you cannot choose to remove only the highlight from the paragraph of a general note since it does not display a highlight in the first place.
 
 Upon deleting an annotation, your view will be switched to the offline tab showing the results of your command.
 
@@ -599,9 +599,9 @@ image::DeleteAnnotationCommandUi2.png[]
 ****
 * `INDEX` is the bookmark that you want to remove annotations of.
  If `INDEX` is invalid, a warning message will be displayed.
-* `PARA_NUM` is the numbered identifier of the paragraph to remove annotation(s) from. `PARA_NUM` must be either `all` or begin with `P` or `S`.
+* `PARA_NUM` is the numbered identifier of the paragraph to remove annotation(s) from. `PARA_NUM` must be either `all` or begin with `P` or `S`. `PARA_NUM` is case-insensitive.
  If you entered `all` for this parameter, all annotations will be cleared regardless of other options, reverting the offline document to a clean slate.
- If you specified a phantom paragraph instead, the phantom paragraph will be deleted if `n/KEEP_NOTES` parameter is set to `false`.
+ If you specified the paragraph of a general note instead, it will be deleted if `n/KEEP_NOTES` parameter is set to `false`.
  If `PARA_NUM` is invalid or there is no annotation to delete, a warning message will be displayed.
 * `KEEP_NOTES` is _boolean_ (either `true` or `false`). If `true`, the notes of the paragraph will not be deleted. Otherwise,
 the notes will be removed. `KEEP_NOTES` is `false` by default.
@@ -620,7 +620,7 @@ This removes both the note and highlight from paragraph 2 in the offline copy of
 This removes the note of paragraph 2 in the offline copy of bookmark 1, leaving the highlight untouched.
 
 * `*annotate-delete* 2 p/g1` +
-This deletes the general note from phantom paragraph `G1` in the offline copy of bookmark 2.
+This deletes the general note `G1` in the offline copy of bookmark 2.
 
 * `*annotate-delete* 1 p/all` +
 This removes all annotations of the offline copy of bookmark 1.
@@ -657,10 +657,10 @@ image::EditAnnotationCommandUi2.png[]
 ****
  * `INDEX` is the bookmark that you want to annotate offline version of.
  If `INDEX` is invalid, a warning message will be displayed.
- * `PARA_NUM` is the numbered identifier of the paragraph which you want to edit annotation of.
+ * `PARA_NUM` is the numbered identifier of the paragraph which you want to edit annotation of. `PARA_NUM` is case-insensitive.
  If `PARA_NUM` is invalid or the corresponding paragraph does not have existing annotations, a warning message will be displayed.
- * `NEW_PARA_NUM` is the numbered identifier of the paragraph to move the annotation to. If `NEW_PARA_NUM` is the same as `PARA_NUM` or
-is invalid, a warning message will be displayed.
+ * `NEW_PARA_NUM` is the numbered identifier of the paragraph to move the annotation to. `NEW_PARA_NUM` is also case-insensitive.
+If `NEW_PARA_NUM` is the same as `PARA_NUM` or is invalid, a warning message will be displayed.
  * `NOTES` is the content of notes to change to. Whenever notes is given, it
  replaces any pre-existing note to paragraph `PARA_NUM`, if applicable.
  * `HIGHLIGHT_COLOUR` is either `orange`, `pink`, `green` or `yellow`. This selects
@@ -686,7 +686,7 @@ This replaces the content of the note for paragraph 1 with "new notes" in the of
 This changes the highlight colour to yellow for paragraph 1 in the offline copy of bookmark 1.
 
 * `*annotate-edit* 1 p/g2 to/p1` +
-This moves the general note of phantom paragraph `S2` to paragraph 1 in the offline copy of bookmark 1.
+This moves the general note `G2` to paragraph 1 in the offline copy of bookmark 1.
 
 * `*annotate-edit* 1 p/p2 to/p3 n/changing and moving notes` +
 This annotates paragraph 3 with the highlight of paragraph 2 and

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -474,35 +474,54 @@ Examples:
 * `*cache-delete* 2` +
 Deletes the offline copy of the second bookmark.
 
+[[annotate]]
 === Making annotations on an offline copy: *`annotate`*
 
-This adds a new annotation on the offline copy of the given bookmarked
-website. When you give this command, the UI will switch to the offline tab showing the results of your command.
-With this command, you can highlight a paragraph on the offline document and optionally attach a supplementary
-note to said paragraph. (You can add notes to justify the highlight or as
-content-relevant notes to refer to in future).
-You can also add a general note not pertaining to any specific paragraph to the bottom of the document,
-hereby known as the _General notes section_.
+If you want to add a new annotation on the offline copy of the given bookmarked
+website, you can do so using the `annotate` command.
+With this command, you can highlight a paragraph on the offline document and
+optionally attach a supplementary note to said paragraph. You can add notes
+to justify the highlight or as content-relevant notes to refer to in future.
 
-NOTE: A general note is known to attach to a <<phantom-paragraph,_phantom paragraph_>>. As you can see in the offline
-copy, phantom paragraphs do not have any content displayed; they do not belong to the original web page.
-The phantom paragraphs altogether make up the _General notes section_.
+If you are looking to add a general note not pertaining to any specific paragraph, you
+can also use this command to add it to the bottom of the page, hereby known as the _General notes section_.
+
+Upon annotating, the your view will be switched to the offline tab
+showing the results of your command.
+
+NOTE: A general note is not attached to any paragraph of the original web page. Instead, when adding general notes, they are attached
+to newly created paragraphs that do not have any content displayed.
+General notes are found at the bottom of the page, referred to as the _General notes section_.
 
 You can choose to use this command to overwrite any existing note. However, note that when you use this command to highlight
 a phantom paragraph, Mark remembers the hidden highlight colour, but no highlight is reflected on the application.
 
-
-NOTE: Paragraphs are identified using a numbered identifier that starts with either `P` or `S`. You can refer to the
+NOTE: Paragraphs are identified using a numbered identifier that starts with either `P` or `G`. You can refer to the
 numbered identifier in the leftmost column of the offline document to check out the respective identifier for each paragraph.
-Phantom paragraphs are identified using numbered identifiers that begin with `S`, as opposed to <<true-paragraph,_true paragraphs_>>, whose identifiers begin with `P`.
+Paragraphs of general notes are identified using numbered identifiers that begin with `G`, as opposed to paragraphs originating from the original web page, whose identifiers begin with `P`.
 
 Format: `*annotate* INDEX p/PARA_NUM [n/NOTES] [h/HIGHLIGHT_COLOUR=yellow]`
 
+For example:
+
+* Provide the index of the bookmark, the paragraph identifier of the paragraph to annotate and any notes or highlight you want to add.
+ `*annotate* 1 p/p2 n/summary of paragraph h/orange`
+
+image::AddAnnotationCommandUi1.png[]
+// offline tab, showing result after   annotate 1 p/p2
+
+* Any pre-existing annotation is overwritten. Paragraph P2 is now highlighted orange and a note with content “summary of paragraph” is attached to it.
+
+image::AddAnnotationCommandUi2.png[]
+// offline tab, showing result.
+
+
+// More details about command constraints
 ****
  * `INDEX` is the bookmark that you want to annotate offline version of.
  If `INDEX` is invalid, a warning message will be displayed.
  * `PARA_NUM` is the numbered identifier of the paragraph to be marked.
- `PARA_NUM` must be `NULL` or it must begin with `P` or `S` (e.g. `P3`).
+ `PARA_NUM` must be `NULL` or it must begin with `P` or `G` (e.g. `P3`).
  If `PARA_NUM` is invalid, a warning message will be displayed.
  * `NOTES` is the content of notes to add.
  * `HIGHLIGHT_COLOUR` is either `orange`, `pink`, `green` or `yellow`. This selects
@@ -511,14 +530,11 @@ the colour is set to yellow by default.
 If the colour provided is invalid, a warning message will be displayed.
 ****
 
-Examples:
+//TODO: remove all the description of result and replace with GUI image?
+Other examples:
 
-* `*annotate* 1 p/p2 n/summary of paragraph h/orange` +
-This highlights paragraph 2 orange and attaches note with content “summary of paragraph” to the paragraph
-in the offline copy of bookmark 1.
-//TODO: add screenshots
-
-
+* `*annotate* 1 p/p2` +
+This highlights paragraph 2 yellow in the offline copy of bookmark 1.
 
 * `*annotate* 1 p/p2 h/pink` +
 This overwrites any existing highlight of paragraph 2 with pink
@@ -530,22 +546,30 @@ in the offline copy of bookmark 1. Highlight
 colour remains the same. Otherwise, paragraph 2 will be highlighted yellow and
 a new note with content "change or add note content" will be added to the paragraph.
 
-* `*annotate* 1 n/adding a general note` +
+* `*annotate* 1 p/null n/adding a general note` +
 This adds a note with content "adding a general note" to the _General notes section_ in the
 offline copy of bookmark 1.
+
 
 [[annotatedelete]]
 === Deleting annotations on an offline copy: *`annotate-delete`*
 
-This deletes selected highlights or notes from the offline copy of the given bookmarked website.
-When you give this command, the UI will switch to the offline tab showing the results of your command.
+If you want to delete highlights or notes from an offline copy of a bookmark, you can do so using the `annotate-delete` command.
 You can choose to remove just the notes and/or highlight of a paragraph, or clear all annotations
 on the offline copy to revert it to a clean slate. You can also choose to remove a note from the
-<<stray-notes,_General notes section_>>. If the given paragraph does not have any annotations to remove, nothing is performed.
+<<stray-notes,_General notes section_>>.
 
-You are not allowed to remove only the highlight from a phantom paragraph since it does not display a highlight in the first place.
+If the given paragraph does not have any annotations to remove, nothing is performed.
+Also, you cannot choose to remove only the highlight from a phantom paragraph since it does not display a highlight in the first place.
+
+Upon deleting an annotation, your view will be switched to the offline tab showing the results of your command.
 
 Format: `*annotate-delete* INDEX p/PARA_NUM [n/KEEP_NOTES=false] [h/KEEP_HIGHLIGHT=false]`
+
+For example:
+
+* Provide the index of the bookmark, the paragraph identifier of the paragraph to annotate and optionally whether
+
 
 ****
 * `INDEX` is the bookmark that you want to remove annotations of.
@@ -895,18 +919,9 @@ The structure of folders in Mark. This is displayed in the dashboard tab when th
 An copy of a bookmarked website that is used for offline viewing. It is stored as a HTML file on the computer.
 
 [[stray-notes]] General notes::
-Annotated notes that are not attached to an existing paragraph are described to be general.
+Annotation notes that are not attached to a paragraph from the corresponding web page are described to be general.
 General notes are found at the bottom of the rightmost column on the offline copy, known as the _General notes section_.
 
-[[phantom-paragraph]] Phantom paragraph::
-A phantom paragraph does not have any displayed content and does not show any highlights. It exists to present the general note you added to the document.
-Phantom paragraphs are identified using a numbered identifier that begins with a `S` (e.g. `S2` refers to the second
-phantom paragraph displayed in the document).
-
-[[true-paragraph]] True paragraph::
-A true paragraph contains content extracted from the original web page. Highlights and notes attached to it are displayed along with the content as well.
-True paragraphs are identified using a numbered identifier that begins with a `P` (e.g. `P2` refers to the third paragraph of the web page
-displayed in the document).
 
 //TODO: Check
 == Command Summary

--- a/src/main/java/seedu/mark/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/mark/logic/parser/ParserUtil.java
@@ -217,9 +217,9 @@ public class ParserUtil {
 
         ParagraphIdentifier.ParagraphType t;
         switch (pidString.charAt(0)) {
-        case 's':
+        case 'g':
             //fallthrough
-        case 'S':
+        case 'G':
             t = ParagraphIdentifier.ParagraphType.STRAY;
             break;
         case 'p':

--- a/src/main/java/seedu/mark/model/annotation/ParagraphIdentifier.java
+++ b/src/main/java/seedu/mark/model/annotation/ParagraphIdentifier.java
@@ -110,7 +110,7 @@ public class ParagraphIdentifier implements Comparable<ParagraphIdentifier> {
             if (this == EXIST) {
                 return "P";
             }
-            return "S";
+            return "G";
         }
     }
 

--- a/src/test/java/seedu/mark/logic/parser/AddAnnotationCommandParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/AddAnnotationCommandParserTest.java
@@ -23,7 +23,7 @@ class AddAnnotationCommandParserTest {
         AddAnnotationCommand expectedNonGeneralCommand = new AddAnnotationCommand(Index.fromOneBased(1),
                 ParagraphIdentifier.makeStrayId(Index.fromOneBased(2)), AnnotationNote.SAMPLE_NOTE, Highlight.PINK);
         assertParseSuccess(parser,
-                PREAMBLE_WHITESPACE + "1 p/ s2   h/  pink n/" + AnnotationNote.SAMPLE_NOTE.toString(),
+                PREAMBLE_WHITESPACE + "1 p/ g2   h/  pink n/" + AnnotationNote.SAMPLE_NOTE.toString(),
                 expectedNonGeneralCommand);
 
         expectedNonGeneralCommand = new AddAnnotationCommand(Index.fromOneBased(1),
@@ -45,7 +45,7 @@ class AddAnnotationCommandParserTest {
         AddAnnotationCommand expectedNonGeneralCommand = new AddAnnotationCommand(Index.fromOneBased(1),
                 ParagraphIdentifier.makeStrayId(Index.fromOneBased(2)), AnnotationNote.SAMPLE_NOTE, Highlight.YELLOW);
         assertParseSuccess(parser,
-                PREAMBLE_WHITESPACE + "1 p/ s2 n/" + AnnotationNote.SAMPLE_NOTE.toString(),
+                PREAMBLE_WHITESPACE + "1 p/ g2 n/" + AnnotationNote.SAMPLE_NOTE.toString(),
                 expectedNonGeneralCommand);
         expectedNonGeneralCommand = new AddAnnotationCommand(Index.fromOneBased(1),
                 ParagraphIdentifier.makeExistId(Index.fromOneBased(2)), AnnotationNote.SAMPLE_NOTE, Highlight.YELLOW);
@@ -59,7 +59,7 @@ class AddAnnotationCommandParserTest {
         AddAnnotationCommand expectedNonGeneralCommand = new AddAnnotationCommand(Index.fromOneBased(1),
                 ParagraphIdentifier.makeStrayId(Index.fromOneBased(2)), null, Highlight.PINK);
         assertParseSuccess(parser,
-                PREAMBLE_WHITESPACE + "1 p/ s2   h/  pink ",
+                PREAMBLE_WHITESPACE + "1 p/ g2   h/  pink ",
                 expectedNonGeneralCommand);
 
         expectedNonGeneralCommand = new AddAnnotationCommand(Index.fromOneBased(1),
@@ -76,7 +76,7 @@ class AddAnnotationCommandParserTest {
                 ParagraphIdentifier.makeStrayId(Index.fromOneBased(2)), null, Highlight.YELLOW);
         //stray invalidity handled in execute of command
         assertParseSuccess(parser,
-                PREAMBLE_WHITESPACE + "1 p/s2",
+                PREAMBLE_WHITESPACE + "1 p/g2",
                 expectedNonGeneralCommand);
 
         expectedNonGeneralCommand = new AddAnnotationCommand(Index.fromOneBased(1),
@@ -90,7 +90,7 @@ class AddAnnotationCommandParserTest {
     @Test
     public void parse_compulsoryIndexMissing_failure() {
         assertParseFailure(parser,
-                PREAMBLE_WHITESPACE + "p/ s2   h/  pink ",
+                PREAMBLE_WHITESPACE + "p/ g2   h/  pink ",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddAnnotationCommand.MESSAGE_USAGE));
     }
 

--- a/src/test/java/seedu/mark/logic/parser/DeleteAnnotationCommandParserTest.java
+++ b/src/test/java/seedu/mark/logic/parser/DeleteAnnotationCommandParserTest.java
@@ -22,17 +22,17 @@ class DeleteAnnotationCommandParserTest {
     @Test
     public void parse_allFieldsPresent_success() {
         assertParseSuccess(parser,
-                PREAMBLE_WHITESPACE + "1 p/ s2   h/ false n/falSe",
+                PREAMBLE_WHITESPACE + "1 p/ g2   h/ false n/falSe",
                 new DeleteAnnotationAllCommand(Index.fromOneBased(1),
                         ParagraphIdentifier.makeStrayId(Index.fromOneBased(2))));
 
         assertParseSuccess(parser,
-                PREAMBLE_WHITESPACE + "1 p/ s2   h/ false n/true",
+                PREAMBLE_WHITESPACE + "1 p/ g2   h/ false n/true",
                 new DeleteAnnotationHighlightCommand(Index.fromOneBased(1),
                         ParagraphIdentifier.makeStrayId(Index.fromOneBased(2))));
 
         assertParseSuccess(parser,
-                PREAMBLE_WHITESPACE + "1 p/ s2   h/ true n/ falSe",
+                PREAMBLE_WHITESPACE + "1 p/ g2   h/ true n/ falSe",
                 new DeleteAnnotationNoteCommand(Index.fromOneBased(1),
                         ParagraphIdentifier.makeStrayId(Index.fromOneBased(2))));
 
@@ -44,11 +44,11 @@ class DeleteAnnotationCommandParserTest {
     @Test
     public void parse_missingOnlyHighlight_success() {
         assertParseSuccess(parser,
-                PREAMBLE_WHITESPACE + "1 p/ s2 n/true",
+                PREAMBLE_WHITESPACE + "1 p/ g2 n/true",
                 new DeleteAnnotationHighlightCommand(Index.fromOneBased(1),
                         ParagraphIdentifier.makeStrayId(Index.fromOneBased(2))));
         assertParseSuccess(parser,
-                PREAMBLE_WHITESPACE + "1 p/ s2 n/false",
+                PREAMBLE_WHITESPACE + "1 p/ g2 n/false",
                 new DeleteAnnotationAllCommand(Index.fromOneBased(1),
                         ParagraphIdentifier.makeStrayId(Index.fromOneBased(2))));
 
@@ -57,11 +57,11 @@ class DeleteAnnotationCommandParserTest {
     @Test
     public void parse_missingOnlyNote_success() {
         assertParseSuccess(parser,
-                PREAMBLE_WHITESPACE + "1 p/ s2 h/true",
+                PREAMBLE_WHITESPACE + "1 p/ g2 h/true",
                 new DeleteAnnotationNoteCommand(Index.fromOneBased(1),
                         ParagraphIdentifier.makeStrayId(Index.fromOneBased(2))));
         assertParseSuccess(parser,
-                PREAMBLE_WHITESPACE + "1 p/ s2 h/false",
+                PREAMBLE_WHITESPACE + "1 p/ g2 h/false",
                 new DeleteAnnotationAllCommand(Index.fromOneBased(1),
                         ParagraphIdentifier.makeStrayId(Index.fromOneBased(2))));
 

--- a/src/test/java/seedu/mark/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/mark/logic/parser/ParserUtilTest.java
@@ -191,9 +191,9 @@ public class ParserUtilTest {
         assertEquals(new ParagraphIdentifier(index, ParagraphIdentifier.ParagraphType.EXIST),
                 ParserUtil.parseParagraphIdentifier("P1"));
         assertEquals(new ParagraphIdentifier(index, ParagraphIdentifier.ParagraphType.STRAY),
-                ParserUtil.parseParagraphIdentifier("s1"));
+                ParserUtil.parseParagraphIdentifier("g1"));
         assertEquals(new ParagraphIdentifier(index, ParagraphIdentifier.ParagraphType.STRAY),
-                ParserUtil.parseParagraphIdentifier("S1"));
+                ParserUtil.parseParagraphIdentifier("G1"));
     }
 
     @Test

--- a/src/test/java/seedu/mark/model/annotation/ParagraphIdentifierTest.java
+++ b/src/test/java/seedu/mark/model/annotation/ParagraphIdentifierTest.java
@@ -42,7 +42,7 @@ class ParagraphIdentifierTest {
     @Test
     public void toString_check() {
         assertEquals("P1", new ParagraphIdentifier(index, ParagraphIdentifier.ParagraphType.EXIST).toString());
-        assertEquals("S1", new ParagraphIdentifier(index, ParagraphIdentifier.ParagraphType.STRAY).toString());
+        assertEquals("G1", new ParagraphIdentifier(index, ParagraphIdentifier.ParagraphType.STRAY).toString());
     }
 
 }


### PR DESCRIPTION
Features changed and requires screenshots:
- annotate
- annotate-delete
- annotate-edit

Others:
- quick start: navigating the GUI also needs screenshots (annotated)

Offline document general paragraphs also changed to be `G#`